### PR TITLE
Load client segments by organization; add /api/client-tags and frontend dropdown fixes

### DIFF
--- a/NovaCRM.Domain/Clients/ClientService.cs
+++ b/NovaCRM.Domain/Clients/ClientService.cs
@@ -171,8 +171,8 @@ public class ClientService : IClientService
         CreateClientRequest trimmed,
         CancellationToken cancellationToken)
     {
-        var statusTags = await _repository.GetStatusTagsAsync(organizationId, cancellationToken);
-        if (trimmed.SegmentTagId is not null && statusTags.All(tag => tag.Id != trimmed.SegmentTagId.Value))
+        var tags = await _repository.GetTagsAsync(organizationId, cancellationToken);
+        if (trimmed.SegmentTagId is not null && tags.All(tag => tag.Id != trimmed.SegmentTagId.Value))
         {
             throw new ArgumentException("The selected segment is invalid for this organization.", nameof(trimmed));
         }

--- a/NovaCRM.Server/Controllers/ClientTagsController.cs
+++ b/NovaCRM.Server/Controllers/ClientTagsController.cs
@@ -1,0 +1,59 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NovaCRM.Domain.Clients;
+using NovaCRM.Server.Contracts.Clients;
+using NovaCRM.Server.Services;
+
+namespace NovaCRM.Server.Controllers;
+
+[ApiController]
+[Route("api/client-tags")]
+[Authorize]
+public class ClientTagsController : ControllerBase
+{
+    private readonly IClientService _clientService;
+    private readonly IOrganizationContext _organizationContext;
+    private readonly ILogger<ClientTagsController> _logger;
+
+    public ClientTagsController(
+        IClientService clientService,
+        IOrganizationContext organizationContext,
+        ILogger<ClientTagsController> logger)
+    {
+        _clientService = clientService;
+        _organizationContext = organizationContext;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyCollection<ClientTagDto>>> GetClientTags(CancellationToken cancellationToken = default)
+    {
+        var organizationId = await _organizationContext.GetOrganizationIdAsync(User, cancellationToken);
+        if (organizationId is null)
+        {
+            _logger.LogWarning(
+                "Unable to load client tags because organization id is missing for user {UserId}.",
+                User.FindFirstValue(ClaimTypes.NameIdentifier));
+            return Unauthorized();
+        }
+
+        try
+        {
+            var tags = await _clientService.GetTagsAsync(organizationId.Value, cancellationToken);
+            return Ok(tags.Select(ClientTagDto.FromDomain).ToList());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load client tags for organization {OrganizationId}.", organizationId);
+            return StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetails
+            {
+                Status = StatusCodes.Status500InternalServerError,
+                Title = "Failed to load client tags.",
+                Detail = "An unexpected error occurred while loading client tags.",
+                Extensions = { ["traceId"] = HttpContext.TraceIdentifier }
+            });
+        }
+    }
+}

--- a/NovaCRM.Server/Services/Clients/ClientRepository.cs
+++ b/NovaCRM.Server/Services/Clients/ClientRepository.cs
@@ -138,7 +138,7 @@ public class ClientRepository : IClientRepository
                 .Where(t => t.OrganizationId == organizationId && t.DeletedAt == null)
                 .FirstOrDefaultAsync(t => t.Id == request.SegmentTagId.Value, cancellationToken);
 
-            if (segmentTag is null || !ClientStatusRules.IsStatusName(segmentTag.Name))
+            if (segmentTag is null)
             {
                 throw new ArgumentException("Segment tag is not valid for this organization.");
             }

--- a/novacrm.client/src/api/clients.ts
+++ b/novacrm.client/src/api/clients.ts
@@ -101,7 +101,7 @@ export async function createClient(payload: CreateClientPayload): Promise<Client
 }
 
 export async function getClientTags(signal?: AbortSignal): Promise<ClientTag[]> {
-    const { data } = await api.get<ClientTag[]>("/clients/tags", { signal });
+    const { data } = await api.get<ClientTag[]>("/client-tags", { signal });
     return data;
 }
 

--- a/novacrm.client/src/styles/clients/index.css
+++ b/novacrm.client/src/styles/clients/index.css
@@ -450,6 +450,17 @@
     font-size: 13px;
 }
 
+.clients-retry {
+    border: none;
+    background: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: var(--accent);
+    cursor: pointer;
+    text-decoration: underline;
+}
+
 .clients-modal__footer {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
### Motivation
- Fix the Segment dropdown to load tags from the `ClientTags` table filtered by the current user's organization and remove the permanent disabled/error state in the UI.
- Ensure the API does not accept organization IDs from the client and instead resolves the organization from the user context, and return readable/logged errors on failure.
- Validate on the backend that a selected segment tag actually belongs to the current organization when creating a client.

### Description
- Add `ClientTagsController` with `GET /api/client-tags` that reads organization id from `IOrganizationContext`, logs missing orgs, and returns `ClientTagDto` list or a `500` `ProblemDetails` on unexpected errors.
- Change segment validation to use all organization-owned tags by switching `GetStatusTagsAsync` to `GetTagsAsync` in `ClientService` and remove the status-only restriction in `ClientRepository` when verifying `SegmentTagId` ownership.
- Frontend: add `getClientTags()` API call to `novacrm.client/src/api/clients.ts` and update `Clients.tsx` to load tags when the Add Client modal opens, with `loadingSegments`, `segmentsError`, a `Retry` action, proper placeholders (`Loading…`, `No segments`) and only disable the `<select>` while loading.
- Add styling for the retry button (`.clients-retry`) and wire cancellation via `AbortController` for the tag load request.

### Testing
- Attempted to run the frontend dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which failed because the HTTPS dev certificate creation via `dotnet dev-certs` failed and prevented starting Vite; no UI integration verification was completed.
- No automated unit/integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69703c623d94832cac307e7ad8bf5938)