### PR TITLE
Client list: add ClientMetrics & ClientTagLinks, hydrate tags/metrics and update DTOs/UI

### DIFF
--- a/NovaCRM.Data/Model/Client.cs
+++ b/NovaCRM.Data/Model/Client.cs
@@ -45,6 +45,8 @@ public partial class Client
 
     public virtual Branch? Branch { get; set; }
 
+    public virtual ClientMetric? ClientMetric { get; set; }
+
     public virtual ICollection<ClientNote> ClientNotes { get; set; } = new List<ClientNote>();
 
     public virtual ICollection<ClientTagLink> ClientTagLinks { get; set; } = new List<ClientTagLink>();

--- a/NovaCRM.Data/Model/ClientMetric.cs
+++ b/NovaCRM.Data/Model/ClientMetric.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace NovaCRM.Data.Model;
+
+public partial class ClientMetric
+{
+    public Guid ClientId { get; set; }
+
+    public Guid OrganizationId { get; set; }
+
+    public DateTime? LastVisitAt { get; set; }
+
+    public decimal? LifetimeValue { get; set; }
+
+    public string? Status { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    public virtual Client Client { get; set; } = null!;
+
+    public virtual Organization Organization { get; set; } = null!;
+}

--- a/NovaCRM.Data/Model/ClientTagLink.cs
+++ b/NovaCRM.Data/Model/ClientTagLink.cs
@@ -5,13 +5,21 @@ namespace NovaCRM.Data.Model;
 
 public partial class ClientTagLink
 {
+    public Guid Id { get; set; }
+
+    public Guid OrganizationId { get; set; }
+
     public Guid ClientId { get; set; }
 
-    public Guid TagId { get; set; }
+    public Guid ClientTagId { get; set; }
 
     public DateTime CreatedAt { get; set; }
 
+    public DateTime? DeletedAt { get; set; }
+
     public virtual Client Client { get; set; } = null!;
+
+    public virtual Organization Organization { get; set; } = null!;
 
     public virtual ClientTag Tag { get; set; } = null!;
 }

--- a/NovaCRM.Data/Model/Organization.cs
+++ b/NovaCRM.Data/Model/Organization.cs
@@ -45,7 +45,11 @@ public partial class Organization
 
     public virtual ICollection<ClientNote> ClientNotes { get; set; } = new List<ClientNote>();
 
+    public virtual ICollection<ClientMetric> ClientMetrics { get; set; } = new List<ClientMetric>();
+
     public virtual ICollection<ClientTag> ClientTags { get; set; } = new List<ClientTag>();
+
+    public virtual ICollection<ClientTagLink> ClientTagLinks { get; set; } = new List<ClientTagLink>();
 
     public virtual ICollection<ClientSegmentDefinition> ClientSegmentDefinitions { get; set; } = new List<ClientSegmentDefinition>();
 

--- a/NovaCRM.Domain/Clients/ClientModels.cs
+++ b/NovaCRM.Domain/Clients/ClientModels.cs
@@ -4,17 +4,14 @@ namespace NovaCRM.Domain.Clients;
 
 public record ClientListItem(
     Guid Id,
-    string Name,
+    string FirstName,
+    string LastName,
     string Phone,
     string? Email,
-    string Status,
-    string? StatusColor,
-    decimal LifetimeValue,
+    IReadOnlyCollection<ClientTag> Tags,
     DateTime? LastVisitAt,
-    decimal Satisfaction,
-    int Visits,
-    IReadOnlyCollection<string> Tags,
-    string? City
+    decimal? LifetimeValue,
+    string? Status
 );
 
 public record ClientDetails(

--- a/NovaCRM.Domain/Clients/ClientService.cs
+++ b/NovaCRM.Domain/Clients/ClientService.cs
@@ -18,7 +18,7 @@ public class ClientService : IClientService
         }
 
         var returning = clients.Count(c => c.TotalVisits > 1);
-        var averageLtv = Math.Round(clients.Average(c => (decimal)c.LifetimeValue), 0);
+        var averageLtv = Math.Round(clients.Average(c => c.LifetimeValue ?? 0m), 0);
         var satisfaction = Math.Round(clients.Average(c => c.Satisfaction), 1);
 
         return new ClientOverview(clients.Count, returning, averageLtv, satisfaction);
@@ -36,24 +36,17 @@ public class ClientService : IClientService
         var filtered = clients
             .Where(client => MatchesSearch(client, normalizedQuery))
             .Where(client => statusTagId is null || client.Tags.Any(tag => tag.Id == statusTagId))
-            .Select(client =>
-            {
-                var status = ResolveStatus(client.Tags);
-                return new ClientListItem(
-                    client.Id,
-                    BuildName(client.FirstName, client.LastName),
-                    client.Phone,
-                    client.Email,
-                    status.Name,
-                    status.Color,
-                    client.LifetimeValue,
-                    client.LastVisitAt,
-                    client.Satisfaction,
-                    client.TotalVisits,
-                    client.Tags.Select(t => t.Name).ToList(),
-                    client.City
-                );
-            })
+            .Select(client => new ClientListItem(
+                client.Id,
+                client.FirstName,
+                client.LastName,
+                client.Phone,
+                client.Email,
+                client.Tags,
+                client.LastVisitAt,
+                client.LifetimeValue,
+                client.Status
+            ))
             .OrderByDescending(x => x.LastVisitAt ?? DateTime.MinValue)
             .ToList();
 

--- a/NovaCRM.Domain/Clients/IClientRepository.cs
+++ b/NovaCRM.Domain/Clients/IClientRepository.cs
@@ -15,13 +15,12 @@ public record ClientRecord(
     string LastName,
     string Phone,
     string? Email,
-    DateTime? LastVisitAt,
-    int TotalVisits,
-    decimal LifetimeValue,
-    decimal Satisfaction,
     IReadOnlyCollection<ClientTag> Tags,
-    string? City,
-    string? MasterName
+    DateTime? LastVisitAt,
+    decimal? LifetimeValue,
+    string? Status,
+    int TotalVisits,
+    decimal Satisfaction
 );
 
 public record ClientDetailsRecord(

--- a/NovaCRM.Server/Contracts/Clients/ClientDtos.cs
+++ b/NovaCRM.Server/Contracts/Clients/ClientDtos.cs
@@ -11,32 +11,26 @@ public record ClientOverviewDto(int TotalClients, int ReturningClients, decimal 
 
 public record ClientListItemDto(
     Guid Id,
-    string Name,
+    string FirstName,
+    string LastName,
     string Phone,
     string? Email,
-    string Status,
-    string? StatusColor,
-    decimal LifetimeValue,
+    IReadOnlyCollection<ClientTagDto> Tags,
     DateTime? LastVisitAt,
-    decimal Satisfaction,
-    int Visits,
-    IReadOnlyCollection<string> Tags,
-    string? City)
+    decimal? LifetimeValue,
+    string? Status)
 {
     public static ClientListItemDto FromDomain(ClientListItem item) =>
         new(
             item.Id,
-            item.Name,
+            item.FirstName,
+            item.LastName,
             item.Phone,
             item.Email,
-            item.Status,
-            item.StatusColor,
-            item.LifetimeValue,
+            item.Tags.Select(ClientTagDto.FromDomain).ToList(),
             item.LastVisitAt,
-            item.Satisfaction,
-            item.Visits,
-            item.Tags,
-            item.City);
+            item.LifetimeValue,
+            item.Status);
 }
 
 public record ClientDetailsDto(

--- a/NovaCRM.Server/Services/Clients/ClientRepository.cs
+++ b/NovaCRM.Server/Services/Clients/ClientRepository.cs
@@ -25,40 +25,81 @@ public class ClientRepository : IClientRepository
                 c.LastName,
                 c.Phone,
                 c.Email,
-                c.LastVisitAt,
                 c.TotalVisits,
-                c.Ltv,
-                Tags = c.ClientTagLinks
-                    .OrderBy(link => link.Tag.Name)
-                    .Select(link => new ClientTag(link.TagId, link.Tag.Name, link.Tag.Color)),
-                City = c.Branch != null ? c.Branch.City : null,
                 Satisfaction = c.Reviews
                     .Where(r => r.DeletedAt == null)
                     .Select(r => (decimal?)r.Rating)
                     .DefaultIfEmpty(0m)
-                    .Average() ?? 0m,
-                Master = c.Appointments
-                    .Where(a => a.DeletedAt == null)
-                    .OrderByDescending(a => a.StartAt)
-                    .Select(a => a.Staff.FirstName + " " + a.Staff.LastName)
-                    .FirstOrDefault()
+                    .Average() ?? 0m
             })
             .ToListAsync(cancellationToken);
 
-        return clients.Select(c => new ClientRecord(
-            c.Id,
-            c.FirstName,
-            c.LastName,
-            c.Phone,
-            c.Email,
-            c.LastVisitAt,
-            c.TotalVisits,
-            c.Ltv,
-            c.Satisfaction,
-            c.Tags.ToList(),
-            c.City,
-            c.Master
-        )).ToList();
+        if (clients.Count == 0)
+        {
+            return Array.Empty<ClientRecord>();
+        }
+
+        var clientIds = clients.Select(c => c.Id).ToList();
+
+        var tags = await _dbContext.ClientTagLinks
+            .AsNoTracking()
+            .Where(link =>
+                link.OrganizationId == organizationId
+                && link.DeletedAt == null
+                && clientIds.Contains(link.ClientId))
+            .Join(
+                _dbContext.ClientTags.AsNoTracking().Where(tag => tag.OrganizationId == organizationId && tag.DeletedAt == null),
+                link => link.ClientTagId,
+                tag => tag.Id,
+                (link, tag) => new
+                {
+                    link.ClientId,
+                    Tag = new ClientTag(tag.Id, tag.Name, tag.Color)
+                })
+            .ToListAsync(cancellationToken);
+
+        var tagsByClient = tags
+            .GroupBy(item => item.ClientId)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyCollection<ClientTag>)group
+                    .OrderBy(item => item.Tag.Name)
+                    .Select(item => item.Tag)
+                    .ToList());
+
+        var metrics = await _dbContext.ClientMetrics
+            .AsNoTracking()
+            .Where(metric => metric.OrganizationId == organizationId && clientIds.Contains(metric.ClientId))
+            .Select(metric => new
+            {
+                metric.ClientId,
+                metric.LastVisitAt,
+                metric.LifetimeValue,
+                metric.Status
+            })
+            .ToListAsync(cancellationToken);
+
+        var metricsByClient = metrics.ToDictionary(item => item.ClientId, item => item);
+
+        return clients.Select(client =>
+        {
+            tagsByClient.TryGetValue(client.Id, out var clientTags);
+            metricsByClient.TryGetValue(client.Id, out var metric);
+
+            return new ClientRecord(
+                client.Id,
+                client.FirstName,
+                client.LastName,
+                client.Phone,
+                client.Email,
+                clientTags ?? Array.Empty<ClientTag>(),
+                metric?.LastVisitAt,
+                metric?.LifetimeValue,
+                metric?.Status,
+                client.TotalVisits,
+                client.Satisfaction
+            );
+        }).ToList();
     }
 
     public async Task<ClientDetailsRecord?> GetClientDetailsAsync(Guid organizationId, Guid clientId, CancellationToken cancellationToken = default)
@@ -78,8 +119,9 @@ public class ClientRepository : IClientRepository
                 c.Ltv,
                 c.Notes,
                 Tags = c.ClientTagLinks
+                    .Where(link => link.OrganizationId == organizationId && link.DeletedAt == null)
                     .OrderBy(link => link.Tag.Name)
-                    .Select(link => new ClientTag(link.TagId, link.Tag.Name, link.Tag.Color)),
+                    .Select(link => new ClientTag(link.ClientTagId, link.Tag.Name, link.Tag.Color)),
                 City = c.Branch != null ? c.Branch.City : null,
                 Master = c.Appointments
                     .Where(a => a.DeletedAt == null)
@@ -174,8 +216,10 @@ public class ClientRepository : IClientRepository
         {
             _dbContext.ClientTagLinks.Add(new Data.Model.ClientTagLink
             {
+                Id = Guid.NewGuid(),
                 ClientId = client.Id,
-                TagId = segmentTag.Id,
+                ClientTagId = segmentTag.Id,
+                OrganizationId = organizationId,
                 CreatedAt = now
             });
         }

--- a/novacrm.client/src/api/clients.ts
+++ b/novacrm.client/src/api/clients.ts
@@ -9,17 +9,14 @@ export interface ClientOverview {
 
 export interface ClientListItem {
     id: string;
-    name: string;
+    firstName: string;
+    lastName: string;
     phone: string;
     email?: string | null;
-    status: string;
-    statusColor?: string | null;
-    lifetimeValue: number;
+    tags: ClientTag[];
     lastVisitAt?: string | null;
-    satisfaction: number;
-    visits: number;
-    tags: string[];
-    city?: string | null;
+    lifetimeValue?: number | null;
+    status?: string | null;
 }
 
 export interface ClientActivityDto {

--- a/novacrm.client/src/pages/Clients.tsx
+++ b/novacrm.client/src/pages/Clients.tsx
@@ -18,6 +18,11 @@ const formatDate = (value?: string | null) => {
     return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 };
 
+const formatLastVisit = (value?: string | null) => {
+    if (!value) return "No visits yet";
+    return formatDate(value);
+};
+
 const statusSlug = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "-");
 
 export default function Clients() {
@@ -89,7 +94,7 @@ export default function Clients() {
             }
         } catch (error: any) {
             if (axios.isCancel?.(error) || error?.name === "CanceledError") return;
-            setClientsError("Failed to load clients");
+            setClientsError("Failed to load clients. Please try again.");
             console.error("Failed to load clients", error?.message ?? error);
         } finally {
             setLoadingList(false);
@@ -308,7 +313,7 @@ export default function Clients() {
                                         <tr>
                                             <td colSpan={5} className="clients-table-empty">
                                                 <div className="clients-error">
-                                                    <p>{clientsError}.</p>
+                                                    <p>{clientsError}</p>
                                                     <button type="button" className="clients-primary" onClick={() => void loadClients(search, statusFilter)}>
                                                         Retry
                                                     </button>
@@ -344,8 +349,9 @@ export default function Clients() {
                                                 <td>
                                                     <div className="clients-table-primary">
                                                         <div className="clients-client-heading">
-                                                            <span className="clients-client-name">{client.name}</span>
-                                                            {client.city && <small className="clients-client-city">{client.city}</small>}
+                                                            <span className="clients-client-name">
+                                                                {client.firstName} {client.lastName}
+                                                            </span>
                                                         </div>
                                                         <div className="clients-client-meta">
                                                             <span>{client.phone}</span>
@@ -355,15 +361,20 @@ export default function Clients() {
                                                 </td>
                                                 <td>
                                                     <div className="clients-client-tags">
-                                                        {client.tags.length ? client.tags.map((tag) => <span key={tag}>{tag}</span>) : "—"}
+                                                        {client.tags.length
+                                                            ? client.tags.map((tag) => (
+                                                                  <span key={tag.id} style={tag.color ? { backgroundColor: tag.color, color: "var(--ink)" } : undefined}>
+                                                                      {tag.name}
+                                                                  </span>
+                                                              ))
+                                                            : "—"}
                                                     </div>
                                                 </td>
-                                                <td>{formatDate(client.lastVisitAt)}</td>
-                                                <td>{formatCurrency(client.lifetimeValue)}</td>
+                                                <td>{formatLastVisit(client.lastVisitAt)}</td>
+                                                <td>{formatCurrency(client.lifetimeValue ?? 0)}</td>
                                                 <td>
                                                     <span
                                                         className={`clients-status clients-status--${statusSlug(client.status || "")}`}
-                                                        style={client.statusColor ? { backgroundColor: client.statusColor } : undefined}
                                                     >
                                                         {client.status || "—"}
                                                     </span>


### PR DESCRIPTION
### Motivation
- Provide organization-scoped clients listing with M:N tag support and fast access to last-visit/LTV/Status without heavy joins or N+1 queries.
- Ensure tags are stored as links (`ClientTagLinks`) with `OrganizationId` and uniqueness constraints to prevent duplicates.
- Introduce a small metrics table (`ClientMetrics`) to serve `LastVisitAt`, `LifetimeValue` and `Status` efficiently for the UI.

### Description
- Add `ClientMetric` model and `DbSet<ClientMetric>` and wire EF configuration with keys, indexes and precision for `LifetimeValue` (`NovaCRM.Data/Model/ClientMetric.cs`, `ApplicationDbContext.cs`).
- Evolve `ClientTagLink` to include `Id`, `OrganizationId`, `ClientTagId`, `DeletedAt` and EF indexes/unique constraint and update relationships (`NovaCRM.Data/Model/ClientTagLink.cs`, `ApplicationDbContext.cs`).
- Update repository to fetch clients scoped by `organizationId`, then batch-load tags and metrics (no N+1) and return enriched `ClientRecord` including tags, `LastVisitAt`, `LifetimeValue`, and `Status` (`NovaCRM.Server/Services/Clients/ClientRepository.cs`).
- Change domain/DTO shapes to expose `FirstName`/`LastName`, tag metadata and nullable metrics, and adapt service/controller to map the new shapes and log/return friendly API errors (`NovaCRM.Domain/Clients/*`, `NovaCRM.Server/Contracts/Clients/ClientDtos.cs`, `NovaCRM.Server/Controllers/ClientsController.cs`).
- Update frontend API types and clients page to render tag chips, show "No visits yet" when `lastVisitAt` is missing, fallback LTV formatting, and improved retry/error messaging (`novacrm.client/src/api/clients.ts`, `novacrm.client/src/pages/Clients.tsx`).

### Testing
- Attempted to run the frontend dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, but it failed due to Vite certificate creation error: `Error: Could not create certificate.`
- No automated backend integration tests were executed in this run; code compiles locally was not verified during this rollout.
- Manual repository-level verification: repository changes were committed including all updated files and new model; further run/build/test should be performed in CI or locally after resolving the Vite cert issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697053bb56f0832cbc644c1e2d3dca18)