### PR TITLE
Use GetClients endpoint without search parameters

### DIFF
--- a/novacrm.client/src/api/clients.ts
+++ b/novacrm.client/src/api/clients.ts
@@ -75,13 +75,7 @@ export async function getClientsOverview(signal?: AbortSignal): Promise<ClientOv
 }
 
 export async function searchClients(params: SearchClientsRequest, signal?: AbortSignal): Promise<ClientListItem[]> {
-    const { search, filter } = params;
-    const filterParam = filter && filter !== "All" ? filter : undefined;
     const { data } = await api.get<ClientListItem[]>("/clients", {
-        params: {
-            search: search?.trim() || undefined,
-            filter: filterParam || undefined,
-        },
         signal,
     });
     return data;


### PR DESCRIPTION
### Motivation
- The client list should be loaded from the controller's `GetClients` implementation which uses the current `organizationId`, so the frontend should call the base `/clients` endpoint and not attempt local search/filtering parameters.

### Description
- Update `searchClients` in `novacrm.client/src/api/clients.ts` to call `GET /clients` without sending `search` or `filter` query parameters and remove the now-unused local `search`/`filter` handling logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987dd2b80b4832cbb76d42d3628e9ff)