### PR TITLE
Redesign Clients page to premium list-first iOS-style UI

### DIFF
--- a/novacrm.client/src/pages/Clients.tsx
+++ b/novacrm.client/src/pages/Clients.tsx
@@ -30,6 +30,8 @@ const formatLastVisit = (value?: string | null) => {
 };
 
 const statusSlug = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+const initialsFor = (firstName?: string, lastName?: string) =>
+    `${firstName?.charAt(0) ?? ""}${lastName?.charAt(0) ?? ""}`.toUpperCase() || "CL";
 
 export default function Clients() {
     const navigate = useNavigate();
@@ -256,54 +258,15 @@ export default function Clients() {
                 <section className="clients-toolbar">
                     <div className="clients-heading">
                         <h1>Clients</h1>
-                        <p>All your guests in one place: visits, value, and activity.</p>
+                        <p>Manage your clients, visits, and value in one place.</p>
                     </div>
-                </section>
-
-                <section className="clients-overview-card">
-                    <header>
-                        <h2>Clients overview</h2>
-                        <span>Real-time metrics from your database</span>
-                    </header>
-                    <div className="clients-metrics-grid">
-                        <article className="clients-metric-card">
-                            <span className="clients-metric-label">Total clients</span>
-                            <strong className="clients-metric-value">
-                                {loadingOverview ? "—" : overview?.totalClients ?? 0}
-                            </strong>
-                            <span className="clients-metric-hint">People in your CRM</span>
-                        </article>
-                        <article className="clients-metric-card">
-                            <span className="clients-metric-label">Returning</span>
-                            <strong className="clients-metric-value">
-                                {loadingOverview ? "—" : overview?.returning ?? 0}
-                            </strong>
-                            <span className="clients-metric-hint">Visited more than once</span>
-                        </article>
-                        <article className="clients-metric-card">
-                            <span className="clients-metric-label">Average LTV</span>
-                            <strong className="clients-metric-value">
-                                {loadingOverview ? "—" : formatCurrency(overview?.averageLtv ?? 0)}
-                            </strong>
-                            <span className="clients-metric-hint">Average revenue per client</span>
-                        </article>
-                        <article className="clients-metric-card">
-                            <span className="clients-metric-label">Satisfaction</span>
-                            <strong className="clients-metric-value">
-                                {loadingOverview ? "—" : (overview?.satisfaction ?? 0).toFixed(1)}
-                            </strong>
-                            <span className="clients-metric-hint">Average rating from reviews</span>
-                        </article>
-                    </div>
-                </section>
-
-                <section className="clients-widget">
-                    <header className="clients-widget__header">
-                        <div className="clients-widget__actions">
-                            <button type="button" className="clients-add" onClick={handleOpenAdd}>
-                                <span className="clients-add__text">Add client</span>
-                                <span className="clients-add__icon">+</span>
-                            </button>
+                    <div className="clients-toolbar__actions">
+                        <button type="button" className="clients-add" onClick={handleOpenAdd}>
+                            <span className="clients-add__text">Add Client</span>
+                            <span className="clients-add__icon">+</span>
+                        </button>
+                        <label className="clients-search-wrap" aria-label="Search clients">
+                            <span className="clients-search-icon" aria-hidden="true">⌕</span>
                             <input
                                 type="search"
                                 className="clients-search"
@@ -311,7 +274,12 @@ export default function Clients() {
                                 value={search}
                                 onChange={(event) => setSearch(event.target.value)}
                             />
-                        </div>
+                        </label>
+                    </div>
+                </section>
+
+                <section className="clients-widget">
+                    <header className="clients-widget__header">
                         <div className="clients-segments" role="tablist" aria-label="Client segments">
                             {statusFilters.map((item) => (
                                 <button
@@ -326,6 +294,24 @@ export default function Clients() {
                                     {item.label}
                                 </button>
                             ))}
+                        </div>
+                        <div className="clients-summary-strip" aria-label="Clients summary">
+                            <article>
+                                <span>Total</span>
+                                <strong>{loadingOverview ? "—" : overview?.totalClients ?? 0}</strong>
+                            </article>
+                            <article>
+                                <span>Returning</span>
+                                <strong>{loadingOverview ? "—" : overview?.returning ?? 0}</strong>
+                            </article>
+                            <article>
+                                <span>Avg LTV</span>
+                                <strong>{loadingOverview ? "—" : formatCurrency(overview?.averageLtv ?? 0)}</strong>
+                            </article>
+                            <article>
+                                <span>Satisfaction</span>
+                                <strong>{loadingOverview ? "—" : (overview?.satisfaction ?? 0).toFixed(1)}</strong>
+                            </article>
                         </div>
                     </header>
 
@@ -354,22 +340,37 @@ export default function Clients() {
                                             </td>
                                         </tr>
                                     ) : loadingList ? (
-                                        <tr>
-                                            <td colSpan={5} className="clients-table-empty">
-                                                Loading clients…
-                                            </td>
-                                        </tr>
+                                        Array.from({ length: 6 }).map((_, index) => (
+                                            <tr key={`loading-${index}`} className="clients-row-loading">
+                                                <td colSpan={5}>
+                                                    <div className="clients-skeleton-row" />
+                                                </td>
+                                            </tr>
+                                        ))
                                     ) : sortedClients.length === 0 ? (
                                         <tr>
                                             <td colSpan={5} className="clients-table-empty">
-                                                No clients found for this query.
+                                                <div className="clients-empty">
+                                                    <span className="clients-empty__icon" aria-hidden="true">◌</span>
+                                                    <h3>No clients yet</h3>
+                                                    <p>
+                                                        {search
+                                                            ? "No clients matched this search. Try another query or clear filters."
+                                                            : "Start building your client base by adding your first client."}
+                                                    </p>
+                                                    {!search && (
+                                                        <button type="button" className="clients-primary" onClick={handleOpenAdd}>
+                                                            Add Client
+                                                        </button>
+                                                    )}
+                                                </div>
                                             </td>
                                         </tr>
                                     ) : (
                                         sortedClients.map((client) => (
                                             <tr
                                                 key={client.id}
-                                                className="clients-table-row"
+                                                className={`clients-table-row${selectedId === client.id ? " is-selected" : ""}`}
                                                 onClick={() => setSelectedId(client.id)}
                                                 tabIndex={0}
                                                 onKeyDown={(event) => {
@@ -382,6 +383,9 @@ export default function Clients() {
                                                 <td>
                                                     <div className="clients-table-primary">
                                                         <div className="clients-client-heading">
+                                                            <span className="clients-avatar">
+                                                                {initialsFor(client.firstName, client.lastName)}
+                                                            </span>
                                                             <span className="clients-client-name">
                                                                 {client.firstName} {client.lastName}
                                                             </span>

--- a/novacrm.client/src/styles/clients/index.css
+++ b/novacrm.client/src/styles/clients/index.css
@@ -1,17 +1,17 @@
 ﻿.clients-page {
     display: flex;
     flex-direction: column;
-    gap: calc(var(--gap) * 2);
-    padding: calc(var(--pad-x) * 2) clamp(16px, 4vw, 48px);
+    gap: clamp(14px, 1.8vw, 20px);
+    padding: calc(var(--gap) * 0.5) var(--pad-x) calc(var(--gap) * 0.8);
     margin-top: var(--header-h);
     width: 100%;
 }
 
 .clients-toolbar {
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     justify-content: space-between;
-    gap: var(--gap);
+    gap: 14px;
     flex-wrap: wrap;
 }
 
@@ -22,92 +22,98 @@
 
 .clients-heading p {
     margin: 0;
-    color: color-mix(in oklab, var(--ink) 60%, transparent);
+    font-size: 14px;
+    color: color-mix(in oklab, var(--ink) 56%, transparent);
 }
 
-.clients-overview-card,
+.clients-toolbar__actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: min(100%, 620px);
+}
+
 .clients-widget {
     border-radius: 20px;
     border: 1px solid var(--card-bd);
     background: var(--card-bg);
-    box-shadow: 0 18px 48px -32px color-mix(in oklab, var(--ink) 18%, transparent);
-    padding: clamp(18px, 3vw, 26px);
+    box-shadow: 0 10px 34px -22px color-mix(in oklab, var(--ink) 22%, transparent);
+    padding: clamp(12px, 2vw, 16px);
     display: flex;
     flex-direction: column;
-    gap: clamp(16px, 2vw, 20px);
+    gap: 12px;
 }
 
-.clients-overview-card header,
 .clients-widget__header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 12px;
     flex-wrap: wrap;
 }
 
-.clients-overview-card h2 {
-    margin: 0;
-    font-size: 18px;
-}
-
-.clients-overview-card span {
-    color: color-mix(in oklab, var(--ink) 60%, transparent);
-}
-
-.clients-metrics-grid {
+.clients-summary-strip {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: var(--gap);
+    grid-template-columns: repeat(4, minmax(90px, 1fr));
+    gap: 8px;
+    width: min(100%, 540px);
 }
 
-.clients-metric-card {
-    padding: 16px;
-    border-radius: 16px;
-    border: 1px solid var(--card-bd);
-    background: color-mix(in oklab, var(--card-bg) 80%, transparent);
+.clients-summary-strip article {
+    border-radius: 14px;
+    border: 1px solid color-mix(in oklab, var(--card-bd) 85%, transparent);
+    background: color-mix(in oklab, var(--ink) 2.5%, var(--card-bg));
+    padding: 8px 10px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
 }
 
-.clients-metric-label {
-    font-size: 13px;
+.clients-summary-strip span {
+    font-size: 11px;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: color-mix(in oklab, var(--ink) 55%, transparent);
+    letter-spacing: 0.06em;
+    color: color-mix(in oklab, var(--ink) 52%, transparent);
 }
 
-.clients-metric-value {
-    font-size: clamp(24px, 4vw, 30px);
-    font-weight: 700;
-}
-
-.clients-metric-hint {
-    font-size: 14px;
-    color: color-mix(in oklab, var(--ink) 55%, transparent);
-}
-
-.clients-widget__actions {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    flex-wrap: nowrap;
+.clients-summary-strip strong {
+    font-size: 15px;
+    font-weight: 650;
 }
 
 .clients-search {
-    flex: 1 1 240px;
-    border-radius: 14px;
-    border: 1px solid var(--card-bd);
-    background: var(--card-bg);
-    padding: 10px 14px;
+    width: 100%;
+    border: 0;
+    background: transparent;
+    padding: 0;
     font-size: 15px;
     color: var(--ink);
 }
 
 .clients-search:focus {
-    outline: 2px solid color-mix(in oklab, var(--accent) 60%, transparent);
-    outline-offset: 2px;
+    outline: none;
+}
+
+.clients-search-wrap {
+    flex: 1;
+    min-width: 240px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in oklab, var(--card-bd) 95%, transparent);
+    background: color-mix(in oklab, var(--ink) 2.6%, var(--card-bg));
+    padding: 11px 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.clients-search-wrap:focus-within {
+    border-color: color-mix(in oklab, var(--accent) 45%, var(--card-bd));
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 16%, transparent);
+}
+
+.clients-search-icon {
+    color: color-mix(in oklab, var(--ink) 45%, transparent);
+    font-size: 14px;
 }
 
 .clients-segments {
@@ -118,13 +124,14 @@
 }
 
 .clients-segment {
-    padding: 6px 14px;
+    padding: 7px 13px;
     border-radius: 999px;
-    border: 1px solid transparent;
-    background: transparent;
+    border: 1px solid color-mix(in oklab, var(--card-bd) 95%, transparent);
+    background: color-mix(in oklab, var(--ink) 2.4%, var(--card-bg));
     color: color-mix(in oklab, var(--ink) 70%, transparent);
     cursor: pointer;
-    font-size: 14px;
+    font-size: 13px;
+    font-weight: 520;
     transition: all 0.15s ease;
 }
 
@@ -133,17 +140,17 @@
 }
 
 .clients-segment.is-active {
-    background: color-mix(in oklab, var(--accent) 18%, transparent);
-    border-color: color-mix(in oklab, var(--accent) 50%, transparent);
+    background: color-mix(in oklab, var(--accent) 14%, var(--card-bg));
+    border-color: color-mix(in oklab, var(--accent) 34%, var(--card-bd));
     color: var(--ink);
 }
 
 .clients-add {
     border: none;
     border-radius: 999px;
-    padding: 10px 20px;
-    font-weight: 600;
-    font-size: 15px;
+    padding: 11px 18px;
+    font-weight: 650;
+    font-size: 14px;
     color: #fff;
     background: linear-gradient(120deg, var(--accent), var(--accent-2));
     cursor: pointer;
@@ -188,8 +195,8 @@
 
 
 .clients-add:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 12px 24px -14px var(--accent-2);
+    transform: translateY(-1px) scale(1.01);
+    box-shadow: 0 14px 28px -18px var(--accent-2);
 }
 
 .clients-add:active {
@@ -197,8 +204,9 @@
 }
 
 .clients-table-card {
-    border-radius: 18px;
-    border: 1px solid var(--card-bd);
+    border-radius: 16px;
+    border: 1px solid color-mix(in oklab, var(--card-bd) 90%, transparent);
+    background: color-mix(in oklab, var(--ink) 1.2%, var(--card-bg));
     overflow: hidden;
 }
 
@@ -209,7 +217,8 @@
 
 .clients-table {
     width: 100%;
-    border-collapse: collapse;
+    border-collapse: separate;
+    border-spacing: 0;
     min-width: 720px;
 }
 
@@ -217,35 +226,46 @@
 .clients-table td {
     padding: 14px 16px;
     text-align: left;
-    border-bottom: 1px solid color-mix(in oklab, var(--card-bd) 75%, transparent);
+    border-bottom: 1px solid color-mix(in oklab, var(--card-bd) 60%, transparent);
 }
 
 .clients-table thead {
-    background: color-mix(in oklab, var(--ink) 4%, transparent);
+    background: color-mix(in oklab, var(--ink) 3%, var(--card-bg));
     position: sticky;
     top: 0;
     z-index: 1;
 }
 
+.clients-table th {
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: color-mix(in oklab, var(--ink) 52%, transparent);
+}
+
 .clients-table-row {
     cursor: pointer;
-    transition: background 0.15s ease;
+    transition: background 0.16s ease;
 }
 
 .clients-table-row:hover {
-    background: color-mix(in oklab, var(--accent) 6%, transparent);
+    background: color-mix(in oklab, var(--accent) 8%, var(--card-bg));
+}
+
+.clients-table-row.is-selected {
+    background: color-mix(in oklab, var(--accent) 10%, var(--card-bg));
 }
 
 .clients-table-primary {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 7px;
 }
 
 .clients-client-heading {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 8px;
 }
 
@@ -253,8 +273,16 @@
     font-weight: 600;
 }
 
-.clients-client-city {
-    color: color-mix(in oklab, var(--ink) 60%, transparent);
+.clients-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    display: inline-grid;
+    place-items: center;
+    font-size: 11px;
+    font-weight: 700;
+    color: color-mix(in oklab, var(--accent) 72%, #1b1730);
+    background: color-mix(in oklab, var(--accent) 18%, var(--card-bg));
 }
 
 .clients-client-meta {
@@ -272,7 +300,7 @@
 }
 
 .clients-client-tags span {
-    background: color-mix(in oklab, var(--ink) 6%, transparent);
+    background: color-mix(in oklab, var(--ink) 7%, transparent);
     border-radius: 999px;
     padding: 3px 10px;
     font-size: 12px;
@@ -325,14 +353,71 @@
 .clients-table-empty {
     text-align: center;
     color: color-mix(in oklab, var(--ink) 60%, transparent);
-    padding: 20px;
+    padding: 28px;
 }
 
 .clients-error {
-    display: inline-flex;
+    width: min(560px, 100%);
+    margin-inline: auto;
+    border-radius: 14px;
+    border: 1px solid color-mix(in oklab, #ff453a 26%, var(--card-bd));
+    background: color-mix(in oklab, #ff453a 8%, var(--card-bg));
+    padding: 14px;
+    display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: space-between;
     gap: 12px;
+}
+
+.clients-empty {
+    display: grid;
+    place-items: center;
+    gap: 8px;
+    max-width: 380px;
+    margin-inline: auto;
+}
+
+.clients-empty h3,
+.clients-empty p {
+    margin: 0;
+}
+
+.clients-empty p {
+    font-size: 14px;
+    color: color-mix(in oklab, var(--ink) 58%, transparent);
+}
+
+.clients-empty__icon {
+    width: 38px;
+    height: 38px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in oklab, var(--card-bd) 90%, transparent);
+    display: inline-grid;
+    place-items: center;
+    color: color-mix(in oklab, var(--ink) 46%, transparent);
+}
+
+.clients-row-loading td {
+    border-bottom: 1px solid color-mix(in oklab, var(--card-bd) 60%, transparent);
+    padding: 12px 16px;
+}
+
+.clients-skeleton-row {
+    height: 44px;
+    border-radius: 12px;
+    background: linear-gradient(
+        90deg,
+        color-mix(in oklab, var(--ink) 5%, transparent) 20%,
+        color-mix(in oklab, var(--ink) 10%, transparent) 50%,
+        color-mix(in oklab, var(--ink) 5%, transparent) 80%
+    );
+    background-size: 220% 100%;
+    animation: clients-shimmer 1.2s linear infinite;
+}
+
+@keyframes clients-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
 }
 
 .clients-modal {
@@ -532,10 +617,13 @@
     .clients-table-scroll {
         max-height: 420px;
     }
+
+    .clients-summary-strip {
+        grid-template-columns: repeat(2, minmax(120px, 1fr));
+    }
 }
 
 @media (max-width: 640px) {
-    .clients-overview-card header,
     .clients-widget__header {
         flex-direction: column;
         align-items: flex-start;
@@ -548,6 +636,10 @@
 
     .clients-table {
         min-width: 520px;
+    }
+
+    .clients-toolbar__actions {
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
### Motivation
- The existing Clients page was top-heavy with large metrics and weak hierarchy, making the clients list feel visually secondary and not aligned with the dashboard's product UI language.  
- The page needed a calmer, more premium iOS-inspired treatment with clearer hierarchy so the list becomes the central working surface.  
- Empty, error, and loading states required polished, usable designs that feel intentional and support daily CRM workflows.

### Description
- Reworked page structure in `novacrm.client/src/pages/Clients.tsx` to promote a list-first layout with a stronger title/subtitle and a compact actions row containing `Add Client` and an integrated search control.  
- Removed the oversized metric cards and replaced them with a lightweight inline summary strip showing `Total`, `Returning`, `Avg LTV`, and `Satisfaction`, making the clients table the dominant element.  
- Modernized the clients list: added avatar initials (`initialsFor`), subtle hover and `is-selected` states, click/keyboard accessibility, skeleton loading rows, and a polished empty state with contextual copy and CTA.  
- Visual polish in `novacrm.client/src/styles/clients/index.css` to match dashboard rhythm and iOS-like feel (soft rounded corners, subtle shadows/borders, refined spacing, tactile filter chips, responsive adjustments, and improved error/placeholder styling).

### Testing
- `npx tsc -b` was run and completed successfully.  
- `npm run build` was attempted but failed in this environment due to a Vite local certificate generation error (environment-specific).  
- `npx eslint src/pages/Clients.tsx` was run and reported existing `@typescript-eslint/no-explicit-any` errors in the file (these are pre-existing/validation warnings that did not block the TypeScript build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f7c37858832c82bc7c28306bd06c)