### PR TITLE
Fix ClientTagLink EF mapping mismatch and add client tag loading test

### DIFF
--- a/NovaCRM.Data/ApplicationDbContext.cs
+++ b/NovaCRM.Data/ApplicationDbContext.cs
@@ -145,8 +145,9 @@ public partial class ApplicationDbContext : DbContext
 
         modelBuilder.Entity<ClientTagLink>(entity =>
         {
+            entity.ToTable("ClientTagLinks");
+            entity.HasKey(e => new { e.ClientId, e.TagId });
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
-            entity.HasIndex(e => new { e.ClientId, e.TagId }).IsUnique();
             entity.HasOne(d => d.Client).WithMany(p => p.ClientTagLinks).HasForeignKey(d => d.ClientId).OnDelete(DeleteBehavior.Cascade);
             entity.HasOne(d => d.Tag).WithMany(p => p.ClientTagLinks).HasForeignKey(d => d.TagId).OnDelete(DeleteBehavior.Cascade);
         });

--- a/NovaCRM.Data/Migrations/20260328120000_FixClientTagLink.cs
+++ b/NovaCRM.Data/Migrations/20260328120000_FixClientTagLink.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NovaCRM.Data.Migrations;
+
+public partial class FixClientTagLink : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_ClientTagLinks_ClientId_TagId",
+            table: "ClientTagLinks");
+
+        migrationBuilder.AddPrimaryKey(
+            name: "PK_ClientTagLinks",
+            table: "ClientTagLinks",
+            columns: new[] { "ClientId", "TagId" });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropPrimaryKey(
+            name: "PK_ClientTagLinks",
+            table: "ClientTagLinks");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ClientTagLinks_ClientId_TagId",
+            table: "ClientTagLinks",
+            columns: new[] { "ClientId", "TagId" },
+            unique: true);
+    }
+}

--- a/NovaCRM.Data/Model/ClientTagLink.cs
+++ b/NovaCRM.Data/Model/ClientTagLink.cs
@@ -6,6 +6,6 @@ public partial class ClientTagLink
     public Guid TagId { get; set; }
     public DateTime CreatedAt { get; set; }
 
-    public virtual Client Client { get; set; } = null!;
-    public virtual ClientTag Tag { get; set; } = null!;
+    public Client Client { get; set; } = null!;
+    public ClientTag Tag { get; set; } = null!;
 }

--- a/NovaCRM.Server.Tests/Clients/ClientRepositoryTests.cs
+++ b/NovaCRM.Server.Tests/Clients/ClientRepositoryTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using NovaCRM.Data;
+using NovaCRM.Data.Model;
+using NovaCRM.Server.Services.Clients;
+
+namespace NovaCRM.Server.Tests.Clients;
+
+public class ClientRepositoryTests
+{
+    [Fact]
+    public async Task Should_Load_Clients_With_Tags()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        var orgId = Guid.NewGuid();
+        var clientId = Guid.NewGuid();
+        var tagId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        await using (var seedDbContext = new ApplicationDbContext(options))
+        {
+            seedDbContext.Organizations.Add(new Organization
+            {
+                Id = orgId,
+                Name = "Test Org",
+                Timezone = "UTC",
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+
+            seedDbContext.Clients.Add(new Client
+            {
+                Id = clientId,
+                OrganizationId = orgId,
+                FirstName = "Ada",
+                LastName = "Lovelace",
+                Phone = "+10000000000",
+                MarketingOptIn = false,
+                TotalVisits = 1,
+                Ltv = 125m,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+
+            seedDbContext.ClientTags.Add(new ClientTag
+            {
+                Id = tagId,
+                OrganizationId = orgId,
+                Name = "VIP",
+                Color = "#ff6600",
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+
+            seedDbContext.ClientTagLinks.Add(new ClientTagLink
+            {
+                ClientId = clientId,
+                TagId = tagId,
+                CreatedAt = now
+            });
+
+            await seedDbContext.SaveChangesAsync();
+        }
+
+        await using var queryDbContext = new ApplicationDbContext(options);
+        var service = new ClientRepository(queryDbContext);
+
+        var result = await service.GetClientsAsync(orgId, CancellationToken.None);
+
+        Assert.NotNull(result);
+        var client = Assert.Single(result);
+        var tag = Assert.Single(client.Tags);
+        Assert.Equal("VIP", tag.Name);
+    }
+}

--- a/NovaCRM.Server.Tests/NovaCRM.Server.Tests.csproj
+++ b/NovaCRM.Server.Tests/NovaCRM.Server.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NovaCRM.Server\NovaCRM.Server.csproj" />
+  </ItemGroup>
+</Project>

--- a/NovaCRM.Server/Services/Clients/ClientRepository.cs
+++ b/NovaCRM.Server/Services/Clients/ClientRepository.cs
@@ -45,7 +45,7 @@ public class ClientRepository : IClientRepository
 
             var tags = await _dbContext.ClientTagLinks
                 .AsNoTracking()
-                .Where(link => clientIds.Contains(link.ClientId))
+                .Where(link => link.ClientId != Guid.Empty && clientIds.Contains(link.ClientId))
                 .Join(
                     _dbContext.ClientTags.AsNoTracking()
                         .Where(tag => tag.OrganizationId == organizationId && tag.DeletedAt == null),

--- a/NovaCRM.sln
+++ b/NovaCRM.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaCRM.Domain", "NovaCRM.D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaCRM.Data", "NovaCRM.Data\NovaCRM.Data.csproj", "{AC4F2699-ED7A-42D7-A141-1427C6777046}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaCRM.Server.Tests", "NovaCRM.Server.Tests\NovaCRM.Server.Tests.csproj", "{8A00E1BB-4F6A-4CD8-89A6-4AA517EFB19B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,6 +36,10 @@ Global
 		{AC4F2699-ED7A-42D7-A141-1427C6777046}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AC4F2699-ED7A-42D7-A141-1427C6777046}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC4F2699-ED7A-42D7-A141-1427C6777046}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A00E1BB-4F6A-4CD8-89A6-4AA517EFB19B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A00E1BB-4F6A-4CD8-89A6-4AA517EFB19B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A00E1BB-4F6A-4CD8-89A6-4AA517EFB19B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A00E1BB-4F6A-4CD8-89A6-4AA517EFB19B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Motivation
- Resolve EF Core model / DB mismatch for `ClientTagLinks` where the table uses `ClientId`/`TagId` pairs and EF required an explicit composite key to avoid runtime errors about missing primary key and missing columns.
- Ensure repository queries load client tags correctly and avoid referencing non-existent fields or producing invalid joins.
- Add an automated test to assert clients are returned with their tags to prevent regressions.

### Description
- Configure `ClientTagLink` mapping in `OnModelCreating` to map to `ClientTagLinks` and set the composite primary key with `entity.HasKey(e => new { e.ClientId, e.TagId });` and preserved FK relations to `Client` and `ClientTag`. 
- Update the `ClientTagLink` entity navigation properties to the required shape (`Client Client` and `ClientTag Tag`) to match the model. 
- Fix the repository join/filter by guarding `ClientId` and ensuring the join uses `TagId` (`.Where(link => link.ClientId != Guid.Empty && clientIds.Contains(link.ClientId))` and join on `link => link.TagId`).
- Add migration `FixClientTagLink` that drops the previous unique index and adds a primary key across `ClientId` and `TagId`. 
- Add a test project and `Should_Load_Clients_With_Tags` unit test which seeds an in-memory DB with organization, client, tag, and link and asserts the client is returned with its `VIP` tag, and add the test project to the solution.

### Testing
- Removed `bin/` and `obj/` directories successfully using `find ... -exec rm -rf {} +`. 
- Attempted `dotnet clean`, `dotnet build`, `dotnet ef migrations add FixClientTagLink`, `dotnet ef database update`, and `dotnet test`, but each failed in this environment because the `dotnet` CLI is not installed (`/bin/bash: dotnet: command not found`). 
- Migration file and unit test were created and committed, but the unit tests could not be executed here due to the missing `dotnet` runtime, so automated test execution status is `not run` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c85644eccc832c8a234a22310cdec4)