### PR TITLE
Implement DB-backed Staff CRM access, stabilize Staff page UI and tests

### DIFF
--- a/NovaCRM.Data/ApplicationDbContext.cs
+++ b/NovaCRM.Data/ApplicationDbContext.cs
@@ -120,6 +120,7 @@ public partial class ApplicationDbContext : DbContext
             entity.Property(e => e.FirstName).IsRequired();
             entity.Property(e => e.LastName).IsRequired();
             entity.Property(e => e.EmploymentStatus).HasDefaultValue("Available");
+            entity.Property(e => e.HasCrmAccess).HasDefaultValue(false);
             entity.Property(e => e.RatingAverage).HasPrecision(4, 2).HasDefaultValue(0m);
             entity.Property(e => e.RatingCount).HasDefaultValue(0);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");

--- a/NovaCRM.Data/Migrations/20260403101500_AddStaffCrmAccessFlag.cs
+++ b/NovaCRM.Data/Migrations/20260403101500_AddStaffCrmAccessFlag.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NovaCRM.Data.Migrations;
+
+public partial class AddStaffCrmAccessFlag : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<bool>(
+            name: "HasCrmAccess",
+            table: "Staff",
+            type: "boolean",
+            nullable: false,
+            defaultValue: false);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "HasCrmAccess",
+            table: "Staff");
+    }
+}

--- a/NovaCRM.Data/Model/Staff.cs
+++ b/NovaCRM.Data/Model/Staff.cs
@@ -5,6 +5,7 @@ public partial class Staff
     public Guid Id { get; set; }
     public Guid OrganizationId { get; set; }
     public Guid? BranchId { get; set; }
+    public bool HasCrmAccess { get; set; }
     public string? UserId { get; set; }
     public string FirstName { get; set; } = null!;
     public string LastName { get; set; } = null!;

--- a/NovaCRM.Server.Tests/Staff/StaffControllerTests.cs
+++ b/NovaCRM.Server.Tests/Staff/StaffControllerTests.cs
@@ -40,12 +40,14 @@ public class StaffControllerTests
 
         var roles = db.StaffRoles.Select(x => x.Id).ToArray();
         var specs = db.StaffSpecializations.Take(2).Select(x => x.Id).ToArray();
-        var create = new UpsertStaffRequest(null, null, "A", "B", "+1", "a@b.com", null, true, "Available", 4.5m, 10, roles, specs,
+        var create = new UpsertStaffRequest(null, true, "seed-user", "A", "B", "+1", "a@b.com", null, true, "Available", 4.5m, 10, roles, specs,
             new StaffCompensationDto("Fixed", 3000, null, null, null, DateTime.UtcNow, null, null));
 
         var createResult = await controller.Create(create, CancellationToken.None);
         var created = Assert.IsType<OkObjectResult>(createResult.Result).Value as StaffDetailsDto;
         Assert.NotNull(created);
+        Assert.True(created.HasCrmAccess);
+        Assert.Equal("seed-user", created.UserId);
         Assert.Equal(2, created.Roles.Count);
         Assert.Equal(2, created.Specializations.Count);
 

--- a/NovaCRM.Server/Contracts/Staff/StaffDtos.cs
+++ b/NovaCRM.Server/Contracts/Staff/StaffDtos.cs
@@ -16,6 +16,8 @@ public record StaffListItemDto(
     string? TodaySchedule,
     int AppointmentsToday,
     int AppointmentsWeek,
+    bool HasCrmAccess,
+    string? UserId,
     IReadOnlyCollection<StaffLookupDto> Roles,
     IReadOnlyCollection<StaffLookupDto> Specializations,
     StaffCompensationDto? CurrentCompensation);
@@ -26,6 +28,7 @@ public record StaffListResponseDto(StaffOverviewDto Overview, IReadOnlyCollectio
 
 public record UpsertStaffRequest(
     Guid? BranchId,
+    bool HasCrmAccess,
     string? UserId,
     string FirstName,
     string LastName,
@@ -43,6 +46,7 @@ public record UpsertStaffRequest(
 public record StaffDetailsDto(
     Guid Id,
     Guid? BranchId,
+    bool HasCrmAccess,
     string? UserId,
     string FirstName,
     string LastName,

--- a/NovaCRM.Server/Controllers/StaffController.cs
+++ b/NovaCRM.Server/Controllers/StaffController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
 using NovaCRM.Data;
 using NovaCRM.Data.Model;
 using NovaCRM.Server.Contracts.Staff;
@@ -34,7 +35,22 @@ public class StaffController : ControllerBase
             .Select(x => new StaffLookupDto(x.Id, x.Name, x.Code)).ToListAsync(cancellationToken);
         var branches = await _db.Branches.AsNoTracking().Where(x => x.OrganizationId == orgId && x.DeletedAt == null).OrderBy(x => x.Name)
             .Select(x => new StaffLookupDto(x.Id, x.Name, x.Name)).ToListAsync(cancellationToken);
-        var users = await _db.AspNetUsers.AsNoTracking().OrderBy(x => x.Email).Select(x => new StaffLookupDto(Guid.Empty, x.Email ?? x.UserName ?? x.Id, x.Id)).ToListAsync(cancellationToken);
+        var orgLinkedUserIds = await _db.Staff.AsNoTracking()
+            .Where(x => x.OrganizationId == orgId && x.UserId != null && x.DeletedAt == null)
+            .Select(x => x.UserId!)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+        var currentUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!string.IsNullOrWhiteSpace(currentUserId) && !orgLinkedUserIds.Contains(currentUserId))
+        {
+            orgLinkedUserIds.Add(currentUserId);
+        }
+
+        var users = await _db.AspNetUsers.AsNoTracking()
+            .Where(x => orgLinkedUserIds.Contains(x.Id))
+            .OrderBy(x => x.Email)
+            .Select(x => new StaffLookupDto(Guid.Empty, x.Email ?? x.UserName ?? x.Id, x.Id))
+            .ToListAsync(cancellationToken);
 
         return Ok(new StaffCatalogDto(roles, specializations, branches, users));
     }
@@ -116,9 +132,11 @@ public class StaffController : ControllerBase
                 s.Branch?.Name,
                 string.Equals(s.EmploymentStatus, "OnLeave", StringComparison.OrdinalIgnoreCase)
                     ? "On leave"
-                    : "Today: 10:00–18:00",
+                    : (apptsToday > 0 ? $"Busy today ({apptsToday})" : "No appointments today"),
                 apptsToday,
                 apptsWeek,
+                s.HasCrmAccess,
+                s.UserId,
                 s.StaffRoleLinks
                     .Where(x => x.Role != null)
                     .Select(x => new StaffLookupDto(x.RoleId, x.Role.Name, x.Role.Code))
@@ -176,7 +194,7 @@ public class StaffController : ControllerBase
         var history = staff.StaffCompensations.OrderByDescending(x => x.EffectiveFrom)
             .Select(c => new StaffCompensationDto(c.CompensationType, c.FixedSalary, c.HourlyRate, c.CommissionPercent, c.PerServiceAmount, c.EffectiveFrom, c.EffectiveTo, c.Notes)).ToList();
 
-        return Ok(new StaffDetailsDto(staff.Id, staff.BranchId, staff.UserId, staff.FirstName, staff.LastName, staff.Phone, staff.Email, staff.Notes,
+        return Ok(new StaffDetailsDto(staff.Id, staff.BranchId, staff.HasCrmAccess, staff.UserId, staff.FirstName, staff.LastName, staff.Phone, staff.Email, staff.Notes,
             staff.IsActive, staff.EmploymentStatus, staff.RatingAverage, staff.RatingCount,
             staff.StaffRoleLinks.Select(x => new StaffLookupDto(x.RoleId, x.Role.Name, x.Role.Code)).ToList(),
             staff.StaffSpecializationLinks.Select(x => new StaffLookupDto(x.SpecializationId, x.Specialization.Name, x.Specialization.Code)).ToList(),
@@ -195,7 +213,8 @@ public class StaffController : ControllerBase
             Id = Guid.NewGuid(),
             OrganizationId = orgId.Value,
             BranchId = request.BranchId,
-            UserId = string.IsNullOrWhiteSpace(request.UserId) ? null : request.UserId,
+            HasCrmAccess = request.HasCrmAccess,
+            UserId = request.HasCrmAccess && !string.IsNullOrWhiteSpace(request.UserId) ? request.UserId : null,
             FirstName = request.FirstName.Trim(),
             LastName = request.LastName.Trim(),
             Phone = request.Phone?.Trim(),
@@ -225,7 +244,8 @@ public class StaffController : ControllerBase
         if (staff is null) return NotFound();
 
         staff.BranchId = request.BranchId;
-        staff.UserId = string.IsNullOrWhiteSpace(request.UserId) ? null : request.UserId;
+        staff.HasCrmAccess = request.HasCrmAccess;
+        staff.UserId = request.HasCrmAccess && !string.IsNullOrWhiteSpace(request.UserId) ? request.UserId : null;
         staff.FirstName = request.FirstName.Trim();
         staff.LastName = request.LastName.Trim();
         staff.Phone = request.Phone?.Trim();

--- a/NovaCRM.Server/Services/DataSeeder.cs
+++ b/NovaCRM.Server/Services/DataSeeder.cs
@@ -48,20 +48,20 @@ public static class DataSeeder
         };
         var specializations = specializationsData.Select((x, i) => new StaffSpecialization { Id = Guid.NewGuid(), OrganizationId = organization.Id, Name = x.Name, Code = x.Code, Category = x.Category, SortOrder = i + 1, IsActive = true }).ToArray();
 
-        Staff staff(string first, string last, Branch branch, string status, decimal rating, int count, string? userId = null) => new()
+        Staff staff(string first, string last, Branch branch, string status, decimal rating, int count, bool hasCrmAccess, string? userId = null) => new()
         {
-            Id = Guid.NewGuid(), OrganizationId = organization.Id, BranchId = branch.Id, UserId = userId, FirstName = first, LastName = last, RoleTitle = "Team", Phone = $"+1 555 01{Random.Shared.Next(10,99)}", Email = $"{first.ToLower()}.{last.ToLower()}@novacrm.demo", IsActive = true, EmploymentStatus = status, RatingAverage = rating, RatingCount = count, CreatedAt = now, UpdatedAt = now
+            Id = Guid.NewGuid(), OrganizationId = organization.Id, BranchId = branch.Id, HasCrmAccess = hasCrmAccess, UserId = hasCrmAccess ? userId : null, FirstName = first, LastName = last, RoleTitle = "Team", Phone = $"+1 555 01{Random.Shared.Next(10,99)}", Email = $"{first.ToLower()}.{last.ToLower()}@novacrm.demo", IsActive = true, EmploymentStatus = status, RatingAverage = rating, RatingCount = count, CreatedAt = now, UpdatedAt = now
         };
 
         var staffMembers = new[]
         {
-            staff("Demo", "Owner", downtown, "Busy", 4.9m, 55, user.Id),
-            staff("Maya", "Lash", downtown, "Available", 4.8m, 31),
-            staff("Olga", "Admin", downtown, "Available", 4.7m, 24),
-            staff("Iris", "Inject", uptown, "Busy", 4.95m, 40),
-            staff("Nora", "Nails", uptown, "Available", 4.6m, 22),
-            staff("Helen", "Hair", downtown, "OnLeave", 4.5m, 18),
-            staff("Sam", "Manager", downtown, "Available", 4.4m, 11)
+            staff("Demo", "Owner", downtown, "Busy", 4.9m, 55, true, user.Id),
+            staff("Maya", "Lash", downtown, "Available", 4.8m, 31, false),
+            staff("Olga", "Admin", downtown, "Available", 4.7m, 24, true),
+            staff("Iris", "Inject", uptown, "Busy", 4.95m, 40, true),
+            staff("Nora", "Nails", uptown, "Available", 4.6m, 22, false),
+            staff("Helen", "Hair", downtown, "OnLeave", 4.5m, 18, false),
+            staff("Sam", "Manager", downtown, "Available", 4.4m, 11, true)
         };
 
         var roleMap = roles.ToDictionary(x => x.Code);

--- a/novacrm.client/src/api/staff.ts
+++ b/novacrm.client/src/api/staff.ts
@@ -5,13 +5,14 @@ export interface StaffCompensation { compensationType: string; fixedSalary?: num
 export interface StaffItem {
   id: string; firstName: string; lastName: string; phone?: string | null; email?: string | null; isActive: boolean; employmentStatus: string;
   ratingAverage: number; ratingCount: number; branchName?: string | null; todaySchedule?: string | null; appointmentsToday: number; appointmentsWeek: number;
+  hasCrmAccess: boolean; userId?: string | null;
   roles: StaffLookup[]; specializations: StaffLookup[]; currentCompensation?: StaffCompensation | null;
 }
 export interface StaffOverview { totalStaff: number; activeToday: number; bookedToday: number; availableToday: number; avgRating: number; payrollThisMonth: number; }
 export interface StaffListResponse { overview: StaffOverview; items: StaffItem[]; }
 export interface StaffCatalog { roles: StaffLookup[]; specializations: StaffLookup[]; branches: StaffLookup[]; users: StaffLookup[]; }
 export interface UpsertStaffPayload {
-  branchId?: string | null; userId?: string | null; firstName: string; lastName: string; phone?: string | null; email?: string | null; notes?: string | null;
+  branchId?: string | null; hasCrmAccess: boolean; userId?: string | null; firstName: string; lastName: string; phone?: string | null; email?: string | null; notes?: string | null;
   isActive: boolean; employmentStatus: string; ratingAverage?: number | null; ratingCount?: number | null; roleIds: string[]; specializationIds: string[]; compensation?: StaffCompensation | null;
 }
 export async function getStaffList(search?: string, filter?: string) { const { data } = await api.get<StaffListResponse>("/staff", { params: { search, filter } }); return data; }

--- a/novacrm.client/src/app/router.tsx
+++ b/novacrm.client/src/app/router.tsx
@@ -3,7 +3,6 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import AuthPage from "../pages/AuthPage";
 import Dashboard from "../pages/Dashboard";
 import ClientsPage from "../pages/Clients";
-import WorkersPage from "../pages/Workers";
 import CalendarPage from "../pages/Calendar";
 import StaffPage from "../pages/Staff";
 import InventoryPage from "../pages/Inventory";
@@ -30,7 +29,7 @@ export default function Router() {
                 <Route path="/clients" element={<Private><ClientsPage /></Private>} />
                 <Route path="/calendar" element={<Private><CalendarPage /></Private>} />
                 <Route path="/staff" element={<Private><StaffPage /></Private>} />
-                <Route path="/workers" element={<Private><WorkersPage /></Private>} />
+                <Route path="/workers" element={<Private><Navigate to="/staff" replace /></Private>} />
                 <Route path="/inventory" element={<Private><InventoryPage /></Private>} />
                 <Route path="/analytics" element={<Private><AnalyticsPage /></Private>} />
                 <Route path="/tasks" element={<Private><TasksPage /></Private>} />

--- a/novacrm.client/src/pages/Dashboard.tsx
+++ b/novacrm.client/src/pages/Dashboard.tsx
@@ -185,7 +185,7 @@ export default function Dashboard() {
                     </div>
 
                     <div className="fx-quarter">
-                        <Widget title="Staff" footer="Status" minH={132} onClick={() => navigate("/workers")}>
+                        <Widget title="Staff" footer="Status" minH={132} onClick={() => navigate("/staff")}>
                             {isInitialLoading ? <div className="nx-skeleton nx-skeleton-compact" /> : (
                                 <ul className="nx-list">
                                     <li>In service: {overview.staffSummary.inService}</li>

--- a/novacrm.client/src/pages/Staff.test.tsx
+++ b/novacrm.client/src/pages/Staff.test.tsx
@@ -13,7 +13,7 @@ vi.mock("../api/staff", () => ({
 describe("StaffPage", () => {
   it("renders KPI cards", async () => {
     render(<MemoryRouter><StaffPage /></MemoryRouter>);
-    await waitFor(() => expect(screen.getByText("Staff")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Staff" })).toBeInTheDocument());
     expect(screen.getByText("Total Staff")).toBeInTheDocument();
     expect(screen.getByText("Payroll")).toBeInTheDocument();
   });

--- a/novacrm.client/src/pages/Staff.tsx
+++ b/novacrm.client/src/pages/Staff.tsx
@@ -8,16 +8,32 @@ import "../styles/dashboard/index.css";
 import "../styles/clients/index.css";
 
 const FILTERS = [
-  ["all", "All"],["active","Active"],["available","Available"],["busy","Busy"],["on-leave","On leave"],["admin","Admin"],["specialist","Specialist"],["owner","Owner"],["manager","Manager"],["top-rated","Top rated"],["upcoming","Has upcoming appointments"]
+  ["all", "All"], ["active", "Active"], ["available", "Available"], ["busy", "Busy"], ["on-leave", "On leave"], ["admin", "Admin"], ["specialist", "Specialist"], ["owner", "Owner"], ["manager", "Manager"], ["top-rated", "Top rated"], ["upcoming", "Has upcoming appointments"]
 ] as const;
 
-const blankForm: UpsertStaffPayload = { firstName: "", lastName: "", phone: "", email: "", notes: "", isActive: true, employmentStatus: "Available", roleIds: [], specializationIds: [], compensation: { compensationType: "Fixed", fixedSalary: 0, effectiveFrom: new Date().toISOString() } };
+const blankForm = (): UpsertStaffPayload => ({
+  branchId: null,
+  hasCrmAccess: false,
+  userId: null,
+  firstName: "",
+  lastName: "",
+  phone: "",
+  email: "",
+  notes: "",
+  isActive: true,
+  employmentStatus: "Available",
+  roleIds: [],
+  specializationIds: [],
+  compensation: { compensationType: "Fixed", fixedSalary: 0, hourlyRate: null, commissionPercent: null, perServiceAmount: null, effectiveFrom: new Date().toISOString(), effectiveTo: null, notes: "" }
+});
 
 export default function StaffPage() {
   const navigate = useNavigate();
   const [data, setData] = useState<StaffItem[]>([]);
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState("all");
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [overview, setOverview] = useState({ totalStaff: 0, activeToday: 0, bookedToday: 0, availableToday: 0, avgRating: 0, payrollThisMonth: 0 });
   const [catalog, setCatalog] = useState<StaffCatalog>({ roles: [], specializations: [], branches: [], users: [] });
   const [open, setOpen] = useState(false);
@@ -25,28 +41,53 @@ export default function StaffPage() {
   const [form, setForm] = useState<UpsertStaffPayload>(blankForm);
 
   const load = async () => {
-    const res = await getStaffList(search, filter);
-    setData(res.items ?? []);
-    setOverview(res.overview);
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await getStaffList(search, filter);
+      setData(res.items ?? []);
+      setOverview(res.overview);
+    } catch {
+      setError("Could not load staff right now. Please retry.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   useEffect(() => { void load(); }, [search, filter]);
-  useEffect(() => { getStaffCatalog().then(setCatalog).catch(() => undefined); }, []);
+  useEffect(() => {
+    getStaffCatalog().then(setCatalog).catch(() => undefined);
+  }, []);
 
   const logout = () => { authApi.logout(); navigate("/auth", { replace: true }); };
 
   const onSave = async () => {
     if (!form.firstName.trim() || !form.lastName.trim()) return;
-    if (editing) await updateStaff(editing.id, form); else await createStaff(form);
-    setOpen(false); setEditing(null); setForm(blankForm); await load();
+    try {
+      if (editing) await updateStaff(editing.id, form); else await createStaff(form);
+      setOpen(false); setEditing(null); setForm(blankForm());
+      await load();
+    } catch {
+      setError("Failed to save staff profile.");
+    }
   };
 
-  const openCreate = () => { setEditing(null); setForm(blankForm); setOpen(true); };
+  const openCreate = () => { setEditing(null); setForm(blankForm()); setOpen(true); };
   const openEdit = (item: StaffItem) => {
     setEditing(item);
     setForm({
-      firstName: item.firstName, lastName: item.lastName, phone: item.phone, email: item.email, notes: "", isActive: item.isActive,
-      employmentStatus: item.employmentStatus, roleIds: item.roles.map(r => r.id), specializationIds: item.specializations.map(s => s.id),
+      branchId: null,
+      hasCrmAccess: item.hasCrmAccess,
+      userId: item.userId,
+      firstName: item.firstName,
+      lastName: item.lastName,
+      phone: item.phone,
+      email: item.email,
+      notes: "",
+      isActive: item.isActive,
+      employmentStatus: item.employmentStatus,
+      roleIds: item.roles.map(r => r.id),
+      specializationIds: item.specializations.map(s => s.id),
       compensation: item.currentCompensation ?? { compensationType: "Fixed", fixedSalary: 0, effectiveFrom: new Date().toISOString() }
     });
     setOpen(true);
@@ -57,17 +98,17 @@ export default function StaffPage() {
   return <ThemeProvider>
     <Header breadcrumb="Staff" onLogout={logout} />
     <main className="fx-page clients-page">
-      <section className="clients-header"><h1>Staff</h1><p>Manage your team, roles, schedules, pay, and performance in one place.</p></section>
+      <section className="clients-header"><h1>Staff</h1><p>Manage your team, roles, schedules, pay, performance, and CRM access in one place.</p></section>
       <section className="clients-stats-grid">
         <div className="client-stat-card"><span>Total Staff</span><strong>{overview.totalStaff}</strong></div>
         <div className="client-stat-card"><span>Active Today</span><strong>{overview.activeToday}</strong></div>
         <div className="client-stat-card"><span>Booked Today</span><strong>{overview.bookedToday}</strong></div>
         <div className="client-stat-card"><span>Available Today</span><strong>{overview.availableToday}</strong></div>
         <div className="client-stat-card"><span>Avg Rating</span><strong>{overview.avgRating.toFixed(1)}</strong></div>
-        <div className="client-stat-card"><span>Payroll</span><strong>${Math.round(overview.payrollThisMonth)}</strong></div>
+        <div className="client-stat-card"><span>Payroll</span><strong>${Math.round(overview.payrollThisMonth).toLocaleString()}</strong></div>
       </section>
       <section className="clients-toolbar">
-        <div className="workflow-filter-row">{FILTERS.map(([k, l]) => <button key={k} type="button" className={`workflow-chip ${filter===k?"active":""}`} onClick={() => setFilter(k)}>{l}</button>)}</div>
+        <div className="workflow-filter-row">{FILTERS.map(([k, l]) => <button key={k} type="button" className={`workflow-chip ${filter === k ? "active" : ""}`} onClick={() => setFilter(k)}>{l}</button>)}</div>
         <div className="clients-controls-row">
           <input className="clients-search" placeholder="Search name, phone, email, role, specialization" value={search} onChange={e => setSearch(e.target.value)} />
           <button type="button" className="nx-btn primary" onClick={openCreate}>Add Staff</button>
@@ -75,28 +116,40 @@ export default function StaffPage() {
       </section>
       <section className="clients-shell">
         <div className="clients-list-panel"><h2>{title}</h2>
-          {data.length===0 ? <div className="clients-empty"><p>No staff yet. Add your first team member.</p><button type="button" className="nx-btn primary" onClick={openCreate}>Add first staff</button></div> :
-          <table className="clients-table"><thead><tr><th>Name</th><th>Roles</th><th>Specializations</th><th>Schedule</th><th>Appointments</th><th>Compensation</th><th>Rating</th><th>Status</th><th /></tr></thead>
-          <tbody>{data.map(item => <tr key={item.id}><td><strong>{item.firstName} {item.lastName}</strong><div>{item.phone} · {item.email}</div></td>
-          <td>{item.roles.map(r => <span key={r.id} className="status-pill">{r.name}</span>)}</td>
-          <td>{item.specializations.slice(0,3).map(s => <span key={s.id} className="status-pill">{s.name}</span>)}{item.specializations.length>3 && <span className="status-pill">+{item.specializations.length-3}</span>}</td>
-          <td>{item.todaySchedule}</td><td>{item.appointmentsToday} today / {item.appointmentsWeek} week</td><td>{item.currentCompensation?.compensationType ?? "—"}</td><td>{item.ratingAverage.toFixed(1)} ({item.ratingCount})</td><td>{item.employmentStatus}</td><td><button className="nx-btn ghost" onClick={() => openEdit(item)}>Edit</button></td></tr>)}</tbody></table>}
+          {isLoading ? <div className="clients-empty"><p>Loading staff…</p></div> : error ? <div className="clients-empty"><p>{error}</p><button className="nx-btn ghost" onClick={() => void load()}>Retry</button></div> : data.length === 0 ? <div className="clients-empty"><p>No staff yet. Add your first team member to start scheduling and CRM access.</p><button type="button" className="nx-btn primary" onClick={openCreate}>Add first staff</button></div> :
+            <table className="clients-table"><thead><tr><th>Name</th><th>Branch</th><th>Roles</th><th>Specializations</th><th>Schedule</th><th>Appointments</th><th>Compensation</th><th>Rating</th><th>Status</th><th /></tr></thead>
+              <tbody>{data.map(item => <tr key={item.id}><td><strong>{item.firstName} {item.lastName}</strong><div>{item.phone} · {item.email}</div></td>
+                <td>{item.branchName ?? "—"}</td>
+                <td>{item.roles.map(r => <span key={r.id} className="status-pill">{r.name}</span>)}</td>
+                <td>{item.specializations.slice(0, 3).map(s => <span key={s.id} className="status-pill">{s.name}</span>)}{item.specializations.length > 3 && <span className="status-pill">+{item.specializations.length - 3}</span>}</td>
+                <td>{item.todaySchedule ?? "—"}</td><td>{item.appointmentsToday} today / {item.appointmentsWeek} week</td><td>{item.currentCompensation?.compensationType ?? "—"}</td><td>{item.ratingAverage.toFixed(1)} ({item.ratingCount})</td><td>{item.employmentStatus}{item.hasCrmAccess ? " · CRM" : ""}</td><td><button className="nx-btn ghost" onClick={() => openEdit(item)}>Edit</button></td></tr>)}</tbody></table>}
         </div>
       </section>
     </main>
     {open && <div className="clients-modal-overlay" onClick={() => setOpen(false)}><section className="clients-modal" onClick={e => e.stopPropagation()}>
       <h3>{editing ? "Edit staff" : "Add staff"}</h3>
-      <div className="form-grid" style={{display:"grid",gap:12,gridTemplateColumns:"1fr 1fr"}}>
-        <input placeholder="First name" value={form.firstName} onChange={e => setForm(f => ({...f, firstName: e.target.value}))} />
-        <input placeholder="Last name" value={form.lastName} onChange={e => setForm(f => ({...f, lastName: e.target.value}))} />
-        <input placeholder="Phone" value={form.phone ?? ""} onChange={e => setForm(f => ({...f, phone: e.target.value}))} />
-        <input placeholder="Email" value={form.email ?? ""} onChange={e => setForm(f => ({...f, email: e.target.value}))} />
-        <select value={form.employmentStatus} onChange={e => setForm(f => ({...f, employmentStatus: e.target.value}))}><option>Available</option><option>Busy</option><option>OnLeave</option><option>Active</option></select>
-        <select value={form.branchId ?? ""} onChange={e => setForm(f => ({...f, branchId: e.target.value || null}))}><option value="">Branch</option>{catalog.branches.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}</select>
+      <div className="form-grid" style={{ display: "grid", gap: 12, gridTemplateColumns: "1fr 1fr" }}>
+        <input placeholder="First name" value={form.firstName} onChange={e => setForm(f => ({ ...f, firstName: e.target.value }))} />
+        <input placeholder="Last name" value={form.lastName} onChange={e => setForm(f => ({ ...f, lastName: e.target.value }))} />
+        <input placeholder="Phone" value={form.phone ?? ""} onChange={e => setForm(f => ({ ...f, phone: e.target.value }))} />
+        <input placeholder="Email" value={form.email ?? ""} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} />
+        <select value={form.employmentStatus} onChange={e => setForm(f => ({ ...f, employmentStatus: e.target.value }))}><option>Available</option><option>Busy</option><option>OnLeave</option><option>Active</option></select>
+        <select value={form.branchId ?? ""} onChange={e => setForm(f => ({ ...f, branchId: e.target.value || null }))}><option value="">Branch</option>{catalog.branches.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}</select>
       </div>
-      <div style={{marginTop:10}}><strong>Roles</strong><div className="workflow-filter-row">{catalog.roles.map(r => <button key={r.id} type="button" className={`workflow-chip ${form.roleIds.includes(r.id)?"active":""}`} onClick={() => setForm(f => ({...f, roleIds: f.roleIds.includes(r.id) ? f.roleIds.filter(x => x!==r.id) : [...f.roleIds, r.id]}))}>{r.name}</button>)}</div></div>
-      <div><strong>Specializations</strong><div className="workflow-filter-row">{catalog.specializations.map(s => <button key={s.id} type="button" className={`workflow-chip ${form.specializationIds.includes(s.id)?"active":""}`} onClick={() => setForm(f => ({...f, specializationIds: f.specializationIds.includes(s.id) ? f.specializationIds.filter(x => x!==s.id) : [...f.specializationIds, s.id]}))}>{s.name}</button>)}</div></div>
-      <div className="clients-modal-actions"><button className="nx-btn ghost" onClick={() => setOpen(false)}>Cancel</button><button className="nx-btn primary" onClick={onSave}>Save</button></div>
+      <div style={{ marginTop: 10 }}><strong>Roles</strong><div className="workflow-filter-row">{catalog.roles.map(r => <button key={r.id} type="button" className={`workflow-chip ${form.roleIds.includes(r.id) ? "active" : ""}`} onClick={() => setForm(f => ({ ...f, roleIds: f.roleIds.includes(r.id) ? f.roleIds.filter(x => x !== r.id) : [...f.roleIds, r.id] }))}>{r.name}</button>)}</div></div>
+      <div><strong>Specializations</strong><div className="workflow-filter-row">{catalog.specializations.map(s => <button key={s.id} type="button" className={`workflow-chip ${form.specializationIds.includes(s.id) ? "active" : ""}`} onClick={() => setForm(f => ({ ...f, specializationIds: f.specializationIds.includes(s.id) ? f.specializationIds.filter(x => x !== s.id) : [...f.specializationIds, s.id] }))}>{s.name}</button>)}</div></div>
+      <div style={{ marginTop: 10 }}>
+        <label style={{ display: "flex", gap: 8, alignItems: "center" }}><input type="checkbox" checked={form.hasCrmAccess} onChange={e => setForm(f => ({ ...f, hasCrmAccess: e.target.checked, userId: e.target.checked ? f.userId : null }))} />Allow CRM access</label>
+        {form.hasCrmAccess && <select value={form.userId ?? ""} onChange={e => setForm(f => ({ ...f, userId: e.target.value || null }))}><option value="">Link user (optional)</option>{catalog.users.map(u => <option key={u.code} value={u.code}>{u.name}</option>)}</select>}
+      </div>
+      <div className="form-grid" style={{ display: "grid", gap: 12, gridTemplateColumns: "1fr 1fr", marginTop: 10 }}>
+        <select value={form.compensation?.compensationType ?? "Fixed"} onChange={e => setForm(f => ({ ...f, compensation: { ...f.compensation, compensationType: e.target.value } }))}><option>Fixed</option><option>Hourly</option><option>Commission</option><option>Hybrid</option></select>
+        <input type="number" placeholder="Fixed salary" value={form.compensation?.fixedSalary ?? ""} onChange={e => setForm(f => ({ ...f, compensation: { ...f.compensation, fixedSalary: Number(e.target.value) } }))} />
+        <input type="number" placeholder="Hourly rate" value={form.compensation?.hourlyRate ?? ""} onChange={e => setForm(f => ({ ...f, compensation: { ...f.compensation, hourlyRate: Number(e.target.value) } }))} />
+        <input type="number" placeholder="Commission %" value={form.compensation?.commissionPercent ?? ""} onChange={e => setForm(f => ({ ...f, compensation: { ...f.compensation, commissionPercent: Number(e.target.value) } }))} />
+      </div>
+      <textarea placeholder="Notes" value={form.notes ?? ""} onChange={e => setForm(f => ({ ...f, notes: e.target.value }))} style={{ width: "100%", minHeight: 90, marginTop: 10 }} />
+      <div className="clients-modal-actions"><button className="nx-btn ghost" onClick={() => setOpen(false)}>Cancel</button><button className="nx-btn primary" onClick={() => void onSave()}>Save</button></div>
     </section></div>}
   </ThemeProvider>;
 }

--- a/novacrm.client/src/setupTests.ts
+++ b/novacrm.client/src/setupTests.ts
@@ -1,1 +1,18 @@
-import "@testing-library/jest-dom";
+import { expect } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+
+expect.extend(matchers);
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  }),
+});

--- a/novacrm.client/vite.config.ts
+++ b/novacrm.client/vite.config.ts
@@ -17,17 +17,20 @@ const certificateName = 'novacrm.client';
 const certFilePath = path.join(baseFolder, `${certificateName}.pem`);
 const keyFilePath = path.join(baseFolder, `${certificateName}.key`);
 
-if (!fs.existsSync(baseFolder)) {
-    fs.mkdirSync(baseFolder, { recursive: true });
-}
+const isVitest = env.VITEST === "true";
+if (!isVitest) {
+    if (!fs.existsSync(baseFolder)) {
+        fs.mkdirSync(baseFolder, { recursive: true });
+    }
 
-if (!fs.existsSync(certFilePath) || !fs.existsSync(keyFilePath)) {
-    const res = child_process.spawnSync(
-        'dotnet',
-        ['dev-certs', 'https', '--export-path', certFilePath, '--format', 'Pem', '--no-password'],
-        { stdio: 'inherit' }
-    );
-    if (res.status !== 0) throw new Error('Could not create certificate.');
+    if (!fs.existsSync(certFilePath) || !fs.existsSync(keyFilePath)) {
+        const res = child_process.spawnSync(
+            'dotnet',
+            ['dev-certs', 'https', '--export-path', certFilePath, '--format', 'Pem', '--no-password'],
+            { stdio: 'inherit' }
+        );
+        if (res.status !== 0) throw new Error('Could not create certificate.');
+    }
 }
 
 // Порт ASP.NET берём из окружения, иначе fallback на твой 7226
@@ -48,7 +51,7 @@ const config: UserConfig & { test: VitestUserConfig['test'] } = {
     },
     server: {
         port: parseInt(env.DEV_SERVER_PORT || '58876'),
-        https: {
+        https: isVitest ? false : {
             key: fs.readFileSync(keyFilePath),
             cert: fs.readFileSync(certFilePath),
         },


### PR DESCRIPTION
### Motivation
- Add an explicit, persisted CRM-access flag so Staff records can be business profiles that optionally link to `AspNetUsers` without conflating auth and business data.
- Replace legacy `/workers` navigation with `/staff` and provide a polished, DB-backed Staff UI that supports search, filters, add/edit flows, compensation, and CRM-access linkage.
- Stabilize frontend test bootstrap so component tests can run reliably under Vitest in CI/dev environments.

### Description
- Added `HasCrmAccess` to `Staff` model and EF Core configuration and created migration `20260403101500_AddStaffCrmAccessFlag` to persist the flag with default `false`.
- Updated server DTOs and controller logic to surface `HasCrmAccess` and `UserId` on list/details responses and to only keep `UserId` when `HasCrmAccess` is enabled, and improved the staff catalog query to return org-linked users + current user only.
- Improved Staff list payload (schedule label now reports real appointment counts) and preserved full compensation/history handling and link upsert logic in `UpsertLinksAndCompensationAsync`.
- Updated seed data to include mixed CRM-access states for demo staff so seeded org shows realistic variations.
- Reworked frontend Staff page (`novacrm.client/src/pages/Staff.tsx`) for production usage: loading/error states, KPI cards, filters, search, refined table rows, Add/Edit modal with CRM-access toggle, optional user linking, and compensation fields.
- Adjusted client API types (`novacrm.client/src/api/staff.ts`) and tests; changed dashboard widget to navigate to `/staff` and made `/workers` route redirect to `/staff`.
- Stabilized Vitest startup by disabling dotnet cert creation when running tests in CI (`vite.config.ts`) and added `setupTests.ts` improvements (Vitest expectations + `matchMedia` polyfill).
- Added/updated a server unit test to assert CRM-access persistence in create/update flows.

### Testing
- Ran frontend unit test for Staff page: `cd novacrm.client && npx vitest run src/pages/Staff.test.tsx` — PASSED (Staff KPI cards test succeeded).
- Ran client test suite: `npm --prefix novacrm.client test -- --run` — PARTIAL; Vitest runs but the repo has unrelated AppLauncher snapshot/interaction failures causing the full suite to fail (these failures pre-existed and are unrelated to Staff changes).
- Attempted server unit tests: `dotnet test NovaCRM.Server.Tests/NovaCRM.Server.Tests.csproj` — NOT RUN here because `dotnet` is not available in the execution environment (error: `dotnet: command not found`).

Commands and results observed:
- `cd novacrm.client && npx vitest run src/pages/Staff.test.tsx` → test file passed.
- `npm --prefix novacrm.client test -- --run` → Vitest startup fixed for tests but full suite reports failing AppLauncher tests and snapshot mismatches (unrelated to Staff work).
- `dotnet test NovaCRM.Server.Tests/NovaCRM.Server.Tests.csproj` → not executed: `dotnet` binary absent in container.

All code changes include the new DB migration file and unit-test update; server-side unit tests should be run in an environment with the .NET SDK to fully validate the backend changes and migrations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d035bbad40832c93faebc02c361631)