### PR TITLE
Staff create/edit: persist CRM access, status, and compensation end-to-end

### DIFF
--- a/NovaCRM.Data/ApplicationDbContext.cs
+++ b/NovaCRM.Data/ApplicationDbContext.cs
@@ -119,7 +119,7 @@ public partial class ApplicationDbContext : DbContext
             entity.HasKey(e => e.Id);
             entity.Property(e => e.FirstName).IsRequired();
             entity.Property(e => e.LastName).IsRequired();
-            entity.Property(e => e.EmploymentStatus).HasDefaultValue("Available");
+            entity.Property(e => e.EmploymentStatus).HasDefaultValue("Active");
             entity.Property(e => e.HasCrmAccess).HasDefaultValue(false);
             entity.Property(e => e.RatingAverage).HasPrecision(4, 2).HasDefaultValue(0m);
             entity.Property(e => e.RatingCount).HasDefaultValue(0);

--- a/NovaCRM.Server.Tests/Staff/StaffControllerTests.cs
+++ b/NovaCRM.Server.Tests/Staff/StaffControllerTests.cs
@@ -40,8 +40,8 @@ public class StaffControllerTests
 
         var roles = db.StaffRoles.Select(x => x.Id).ToArray();
         var specs = db.StaffSpecializations.Take(2).Select(x => x.Id).ToArray();
-        var create = new UpsertStaffRequest(null, true, "seed-user", "A", "B", "+1", "a@b.com", null, true, "Available", 4.5m, 10, roles, specs,
-            new StaffCompensationDto("Fixed", 3000, null, null, null, DateTime.UtcNow, null, null));
+        var create = new UpsertStaffRequest(null, true, "seed-user", "A", "B", "+1", "a@b.com", null, true, "Active", 4.5m, 10, roles, specs,
+            "FixedSalary", 3000, null, null);
 
         var createResult = await controller.Create(create, CancellationToken.None);
         var created = Assert.IsType<OkObjectResult>(createResult.Result).Value as StaffDetailsDto;
@@ -52,13 +52,14 @@ public class StaffControllerTests
         Assert.Equal(2, created.Specializations.Count);
 
         var updatedSpecs = db.StaffSpecializations.Skip(1).Select(x => x.Id).ToArray();
-        var updateRequest = create with { SpecializationIds = updatedSpecs, Compensation = new StaffCompensationDto("Hybrid", 3200, null, 15, null, DateTime.UtcNow, null, "raise") };
+        var updateRequest = create with { SpecializationIds = updatedSpecs, CompensationType = "Commission", FixedSalary = 3200, CommissionPercent = 15 };
         var updateResult = await controller.Update(created.Id, updateRequest, CancellationToken.None);
         var updated = Assert.IsType<OkObjectResult>(updateResult.Result).Value as StaffDetailsDto;
 
         Assert.NotNull(updated);
         Assert.Equal(2, updated.Specializations.Count);
-        Assert.Equal("Hybrid", updated.CurrentCompensation?.CompensationType);
+        Assert.Equal("Commission", updated.CurrentCompensation?.CompensationType);
+        Assert.Null(updated.CurrentCompensation?.FixedSalary);
         Assert.True(updated.CompensationHistory.Count >= 2);
     }
 

--- a/NovaCRM.Server/Contracts/Staff/StaffDtos.cs
+++ b/NovaCRM.Server/Contracts/Staff/StaffDtos.cs
@@ -42,7 +42,10 @@ public record UpsertStaffRequest(
     int? RatingCount,
     IReadOnlyCollection<Guid> RoleIds,
     IReadOnlyCollection<Guid> SpecializationIds,
-    StaffCompensationDto? Compensation);
+    string CompensationType,
+    decimal? FixedSalary,
+    decimal? HourlyRate,
+    decimal? CommissionPercent);
 
 public record StaffDetailsDto(
     Guid Id,

--- a/NovaCRM.Server/Controllers/StaffController.cs
+++ b/NovaCRM.Server/Controllers/StaffController.cs
@@ -23,6 +23,20 @@ public class StaffController : ControllerBase
         _organizationContext = organizationContext;
     }
 
+    private static readonly HashSet<string> AllowedEmploymentStatuses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Active",
+        "Vacation",
+        "Terminated"
+    };
+
+    private static readonly HashSet<string> AllowedCompensationTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "FixedSalary",
+        "HourlyRate",
+        "Commission"
+    };
+
     [HttpGet("catalog")]
     public async Task<ActionResult<StaffCatalogDto>> GetCatalog(CancellationToken cancellationToken)
     {
@@ -131,8 +145,8 @@ public class StaffController : ControllerBase
                 s.RatingCount,
                 s.BranchId,
                 s.Branch?.Name,
-                string.Equals(s.EmploymentStatus, "OnLeave", StringComparison.OrdinalIgnoreCase)
-                    ? "On leave"
+                string.Equals(s.EmploymentStatus, "Vacation", StringComparison.OrdinalIgnoreCase)
+                    ? "On vacation"
                     : (apptsToday > 0 ? $"Busy today ({apptsToday})" : "No appointments today"),
                 apptsToday,
                 apptsWeek,
@@ -146,17 +160,7 @@ public class StaffController : ControllerBase
                     .Where(x => x.Specialization != null)
                     .Select(x => new StaffLookupDto(x.SpecializationId, x.Specialization.Name, x.Specialization.Code))
                     .ToList(),
-                currentComp == null
-                    ? null
-                    : new StaffCompensationDto(
-                        currentComp.CompensationType,
-                        currentComp.FixedSalary,
-                        currentComp.HourlyRate,
-                        currentComp.CommissionPercent,
-                        currentComp.PerServiceAmount,
-                        currentComp.EffectiveFrom,
-                        currentComp.EffectiveTo,
-                        currentComp.Notes)
+                currentComp == null ? null : ToCompensationDto(currentComp)
             );
         }).ToList();
 
@@ -192,14 +196,16 @@ public class StaffController : ControllerBase
         if (staff is null) return NotFound();
 
         var currentComp = staff.StaffCompensations.OrderByDescending(x => x.EffectiveFrom).FirstOrDefault();
-        var history = staff.StaffCompensations.OrderByDescending(x => x.EffectiveFrom)
-            .Select(c => new StaffCompensationDto(c.CompensationType, c.FixedSalary, c.HourlyRate, c.CommissionPercent, c.PerServiceAmount, c.EffectiveFrom, c.EffectiveTo, c.Notes)).ToList();
+        var history = staff.StaffCompensations
+            .OrderByDescending(x => x.EffectiveFrom)
+            .Select(ToCompensationDto)
+            .ToList();
 
         return Ok(new StaffDetailsDto(staff.Id, staff.BranchId, staff.HasCrmAccess, staff.UserId, staff.FirstName, staff.LastName, staff.Phone, staff.Email, staff.Notes,
             staff.IsActive, staff.EmploymentStatus, staff.RatingAverage, staff.RatingCount,
             staff.StaffRoleLinks.Select(x => new StaffLookupDto(x.RoleId, x.Role.Name, x.Role.Code)).ToList(),
             staff.StaffSpecializationLinks.Select(x => new StaffLookupDto(x.SpecializationId, x.Specialization.Name, x.Specialization.Code)).ToList(),
-            currentComp is null ? null : new StaffCompensationDto(currentComp.CompensationType, currentComp.FixedSalary, currentComp.HourlyRate, currentComp.CommissionPercent, currentComp.PerServiceAmount, currentComp.EffectiveFrom, currentComp.EffectiveTo, currentComp.Notes), history));
+            currentComp is null ? null : ToCompensationDto(currentComp), history));
     }
 
     [HttpPost]
@@ -207,6 +213,20 @@ public class StaffController : ControllerBase
     {
         var orgId = await _organizationContext.GetOrganizationIdAsync(User, cancellationToken);
         if (orgId is null) return Unauthorized();
+
+        var normalizedStatus = NormalizeEmploymentStatus(request.EmploymentStatus);
+        if (normalizedStatus is null)
+        {
+            return BadRequest("EmploymentStatus must be one of: Active, Vacation, Terminated.");
+        }
+
+        var normalizedCompensationType = NormalizeCompensationType(request.CompensationType);
+        if (normalizedCompensationType is null)
+        {
+            return BadRequest("CompensationType must be one of: FixedSalary, HourlyRate, Commission.");
+        }
+
+        var (fixedSalary, hourlyRate, commissionPercent) = NormalizeCompensationValues(normalizedCompensationType, request.FixedSalary, request.HourlyRate, request.CommissionPercent);
 
         var now = DateTime.UtcNow;
         var staff = new Staff
@@ -222,7 +242,7 @@ public class StaffController : ControllerBase
             Email = request.Email?.Trim(),
             Notes = request.Notes?.Trim(),
             IsActive = request.IsActive,
-            EmploymentStatus = request.EmploymentStatus,
+            EmploymentStatus = normalizedStatus,
             RatingAverage = request.RatingAverage ?? 0,
             RatingCount = request.RatingCount ?? 0,
             CreatedAt = now,
@@ -231,7 +251,7 @@ public class StaffController : ControllerBase
 
         _db.Staff.Add(staff);
         await _db.SaveChangesAsync(cancellationToken);
-        await UpsertLinksAndCompensationAsync(staff.Id, orgId.Value, request, cancellationToken);
+        await UpsertLinksAndCompensationAsync(staff.Id, orgId.Value, request, normalizedCompensationType, fixedSalary, hourlyRate, commissionPercent, cancellationToken);
         return await GetById(staff.Id, cancellationToken);
     }
 
@@ -244,6 +264,20 @@ public class StaffController : ControllerBase
         var staff = await _db.Staff.FirstOrDefaultAsync(s => s.OrganizationId == orgId && s.Id == id && s.DeletedAt == null, cancellationToken);
         if (staff is null) return NotFound();
 
+        var normalizedStatus = NormalizeEmploymentStatus(request.EmploymentStatus);
+        if (normalizedStatus is null)
+        {
+            return BadRequest("EmploymentStatus must be one of: Active, Vacation, Terminated.");
+        }
+
+        var normalizedCompensationType = NormalizeCompensationType(request.CompensationType);
+        if (normalizedCompensationType is null)
+        {
+            return BadRequest("CompensationType must be one of: FixedSalary, HourlyRate, Commission.");
+        }
+
+        var (fixedSalary, hourlyRate, commissionPercent) = NormalizeCompensationValues(normalizedCompensationType, request.FixedSalary, request.HourlyRate, request.CommissionPercent);
+
         staff.BranchId = request.BranchId;
         staff.HasCrmAccess = request.HasCrmAccess;
         staff.UserId = request.HasCrmAccess && !string.IsNullOrWhiteSpace(request.UserId) ? request.UserId : null;
@@ -253,13 +287,13 @@ public class StaffController : ControllerBase
         staff.Email = request.Email?.Trim();
         staff.Notes = request.Notes?.Trim();
         staff.IsActive = request.IsActive;
-        staff.EmploymentStatus = request.EmploymentStatus;
+        staff.EmploymentStatus = normalizedStatus;
         staff.RatingAverage = request.RatingAverage ?? staff.RatingAverage;
         staff.RatingCount = request.RatingCount ?? staff.RatingCount;
         staff.UpdatedAt = DateTime.UtcNow;
 
         await _db.SaveChangesAsync(cancellationToken);
-        await UpsertLinksAndCompensationAsync(staff.Id, orgId.Value, request, cancellationToken);
+        await UpsertLinksAndCompensationAsync(staff.Id, orgId.Value, request, normalizedCompensationType, fixedSalary, hourlyRate, commissionPercent, cancellationToken);
         return await GetById(staff.Id, cancellationToken);
     }
 
@@ -270,7 +304,7 @@ public class StaffController : ControllerBase
             "active" => source.Where(x => x.IsActive && x.EmploymentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase)).ToList(),
             "available" => source.Where(x => x.IsActive && x.EmploymentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase) && x.AppointmentsToday == 0).ToList(),
             "busy" => source.Where(x => x.IsActive && x.EmploymentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase) && x.AppointmentsToday > 0).ToList(),
-            "on-leave" => source.Where(x => x.EmploymentStatus.Equals("OnLeave", StringComparison.OrdinalIgnoreCase)).ToList(),
+            "on-leave" => source.Where(x => x.EmploymentStatus.Equals("Vacation", StringComparison.OrdinalIgnoreCase)).ToList(),
             "admin" => source.Where(x => x.Roles.Any(r => r.Code == "admin")).ToList(),
             "specialist" => source.Where(x => x.Roles.Any(r => r.Code == "specialist")).ToList(),
             "owner" => source.Where(x => x.Roles.Any(r => r.Code == "owner")).ToList(),
@@ -281,10 +315,20 @@ public class StaffController : ControllerBase
         };
     }
 
-    private async Task UpsertLinksAndCompensationAsync(Guid staffId, Guid orgId, UpsertStaffRequest request, CancellationToken cancellationToken)
+    private async Task UpsertLinksAndCompensationAsync(
+        Guid staffId,
+        Guid orgId,
+        UpsertStaffRequest request,
+        string compensationType,
+        decimal? fixedSalary,
+        decimal? hourlyRate,
+        decimal? commissionPercent,
+        CancellationToken cancellationToken)
     {
-        var roleIds = await _db.StaffRoles.Where(r => r.OrganizationId == orgId && request.RoleIds.Contains(r.Id)).Select(r => r.Id).ToListAsync(cancellationToken);
-        var specIds = await _db.StaffSpecializations.Where(s => s.OrganizationId == orgId && request.SpecializationIds.Contains(s.Id)).Select(s => s.Id).ToListAsync(cancellationToken);
+        var requestRoleIds = request.RoleIds ?? Array.Empty<Guid>();
+        var requestSpecIds = request.SpecializationIds ?? Array.Empty<Guid>();
+        var roleIds = await _db.StaffRoles.Where(r => r.OrganizationId == orgId && requestRoleIds.Contains(r.Id)).Select(r => r.Id).ToListAsync(cancellationToken);
+        var specIds = await _db.StaffSpecializations.Where(s => s.OrganizationId == orgId && requestSpecIds.Contains(s.Id)).Select(s => s.Id).ToListAsync(cancellationToken);
 
         var currentRoles = _db.StaffRoleLinks.Where(x => x.StaffId == staffId);
         _db.StaffRoleLinks.RemoveRange(currentRoles);
@@ -294,39 +338,102 @@ public class StaffController : ControllerBase
         _db.StaffSpecializationLinks.RemoveRange(currentSpecs);
         _db.StaffSpecializationLinks.AddRange(specIds.Select(id => new StaffSpecializationLink { StaffId = staffId, SpecializationId = id, CreatedAt = DateTime.UtcNow }));
 
-        if (request.Compensation is not null)
+        var latest = await _db.StaffCompensations.Where(x => x.StaffId == staffId).OrderByDescending(x => x.EffectiveFrom).FirstOrDefaultAsync(cancellationToken);
+        if (latest is null ||
+            !string.Equals(latest.CompensationType, compensationType, StringComparison.OrdinalIgnoreCase) ||
+            latest.FixedSalary != fixedSalary ||
+            latest.HourlyRate != hourlyRate ||
+            latest.CommissionPercent != commissionPercent)
         {
-            var latest = await _db.StaffCompensations.Where(x => x.StaffId == staffId).OrderByDescending(x => x.EffectiveFrom).FirstOrDefaultAsync(cancellationToken);
-            if (latest is null || latest.CompensationType != request.Compensation.CompensationType || latest.FixedSalary != request.Compensation.FixedSalary || latest.HourlyRate != request.Compensation.HourlyRate || latest.CommissionPercent != request.Compensation.CommissionPercent || latest.PerServiceAmount != request.Compensation.PerServiceAmount)
+            _db.StaffCompensations.Add(new StaffCompensation
             {
-                _db.StaffCompensations.Add(new StaffCompensation
-                {
-                    Id = Guid.NewGuid(),
-                    StaffId = staffId,
-                    CompensationType = request.Compensation.CompensationType,
-                    FixedSalary = request.Compensation.FixedSalary,
-                    HourlyRate = request.Compensation.HourlyRate,
-                    CommissionPercent = request.Compensation.CommissionPercent,
-                    PerServiceAmount = request.Compensation.PerServiceAmount,
-                    EffectiveFrom = request.Compensation.EffectiveFrom == default ? DateTime.UtcNow : request.Compensation.EffectiveFrom,
-                    EffectiveTo = request.Compensation.EffectiveTo,
-                    Notes = request.Compensation.Notes,
-                    CreatedAt = DateTime.UtcNow
-                });
+                Id = Guid.NewGuid(),
+                StaffId = staffId,
+                CompensationType = compensationType,
+                FixedSalary = fixedSalary,
+                HourlyRate = hourlyRate,
+                CommissionPercent = commissionPercent,
+                PerServiceAmount = null,
+                EffectiveFrom = DateTime.UtcNow,
+                EffectiveTo = null,
+                Notes = null,
+                CreatedAt = DateTime.UtcNow
+            });
 
-                _db.StaffCompensationHistories.Add(new StaffCompensationHistory
-                {
-                    Id = Guid.NewGuid(),
-                    StaffId = staffId,
-                    PreviousSnapshot = latest is null ? null : $"{latest.CompensationType}:{latest.FixedSalary}:{latest.HourlyRate}:{latest.CommissionPercent}:{latest.PerServiceAmount}",
-                    NewSnapshot = $"{request.Compensation.CompensationType}:{request.Compensation.FixedSalary}:{request.Compensation.HourlyRate}:{request.Compensation.CommissionPercent}:{request.Compensation.PerServiceAmount}",
-                    ChangedAt = DateTime.UtcNow,
-                    ChangedBy = User.Identity?.Name,
-                    Notes = request.Compensation.Notes
-                });
-            }
+            _db.StaffCompensationHistories.Add(new StaffCompensationHistory
+            {
+                Id = Guid.NewGuid(),
+                StaffId = staffId,
+                PreviousSnapshot = latest is null ? null : $"{latest.CompensationType}:{latest.FixedSalary}:{latest.HourlyRate}:{latest.CommissionPercent}:{latest.PerServiceAmount}",
+                NewSnapshot = $"{compensationType}:{fixedSalary}:{hourlyRate}:{commissionPercent}:",
+                ChangedAt = DateTime.UtcNow,
+                ChangedBy = User.Identity?.Name,
+                Notes = null
+            });
         }
 
         await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    private static string? NormalizeEmploymentStatus(string? status)
+    {
+        if (string.IsNullOrWhiteSpace(status))
+        {
+            return null;
+        }
+
+        var normalized = status.Trim();
+        if (string.Equals(normalized, "OnLeave", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = "Vacation";
+        }
+
+        return AllowedEmploymentStatuses.Contains(normalized) ? AllowedEmploymentStatuses.Single(x => x.Equals(normalized, StringComparison.OrdinalIgnoreCase)) : null;
+    }
+
+    private static string? NormalizeCompensationType(string? compensationType)
+    {
+        if (string.IsNullOrWhiteSpace(compensationType))
+        {
+            return null;
+        }
+
+        var normalized = compensationType.Trim();
+        normalized = normalized switch
+        {
+            "Fixed" => "FixedSalary",
+            "Hourly" => "HourlyRate",
+            _ => normalized
+        };
+
+        return AllowedCompensationTypes.Contains(normalized)
+            ? AllowedCompensationTypes.Single(x => x.Equals(normalized, StringComparison.OrdinalIgnoreCase))
+            : null;
+    }
+
+    private static (decimal? FixedSalary, decimal? HourlyRate, decimal? CommissionPercent) NormalizeCompensationValues(string compensationType, decimal? fixedSalary, decimal? hourlyRate, decimal? commissionPercent)
+    {
+        return compensationType switch
+        {
+            "FixedSalary" => (fixedSalary, null, null),
+            "HourlyRate" => (null, hourlyRate, null),
+            "Commission" => (null, null, commissionPercent),
+            _ => (null, null, null)
+        };
+    }
+
+    private static StaffCompensationDto ToCompensationDto(StaffCompensation compensation)
+    {
+        var normalizedCompensationType = NormalizeCompensationType(compensation.CompensationType) ?? "FixedSalary";
+        var (fixedSalary, hourlyRate, commissionPercent) = NormalizeCompensationValues(normalizedCompensationType, compensation.FixedSalary, compensation.HourlyRate, compensation.CommissionPercent);
+        return new StaffCompensationDto(
+            normalizedCompensationType,
+            fixedSalary,
+            hourlyRate,
+            commissionPercent,
+            null,
+            compensation.EffectiveFrom,
+            compensation.EffectiveTo,
+            compensation.Notes);
     }
 }

--- a/novacrm.client/src/api/staff.ts
+++ b/novacrm.client/src/api/staff.ts
@@ -2,6 +2,9 @@ import { api } from "../app/auth";
 
 export interface StaffLookup { id: string; name: string; code: string; }
 export interface StaffCompensation { compensationType: string; fixedSalary?: number | null; hourlyRate?: number | null; commissionPercent?: number | null; perServiceAmount?: number | null; effectiveFrom: string; effectiveTo?: string | null; notes?: string | null; }
+export interface StaffDetails extends StaffItem {
+  notes?: string | null;
+}
 export interface StaffItem {
   id: string; firstName: string; lastName: string; phone?: string | null; email?: string | null; isActive: boolean; employmentStatus: string;
   ratingAverage: number; ratingCount: number; branchId?: string | null; branchName?: string | null; todaySchedule?: string | null; appointmentsToday: number; appointmentsWeek: number;
@@ -13,9 +16,11 @@ export interface StaffListResponse { overview: StaffOverview; items: StaffItem[]
 export interface StaffCatalog { roles: StaffLookup[]; specializations: StaffLookup[]; branches: StaffLookup[]; users: StaffLookup[]; }
 export interface UpsertStaffPayload {
   branchId?: string | null; hasCrmAccess: boolean; userId?: string | null; firstName: string; lastName: string; phone?: string | null; email?: string | null; notes?: string | null;
-  isActive: boolean; employmentStatus: string; ratingAverage?: number | null; ratingCount?: number | null; roleIds: string[]; specializationIds: string[]; compensation?: StaffCompensation | null;
+  isActive: boolean; employmentStatus: string; ratingAverage?: number | null; ratingCount?: number | null; roleIds: string[]; specializationIds: string[];
+  compensationType: string; fixedSalary?: number | null; hourlyRate?: number | null; commissionPercent?: number | null;
 }
 export async function getStaffList(search?: string, filter?: string) { const { data } = await api.get<StaffListResponse>("/staff", { params: { search, filter } }); return data; }
 export async function getStaffCatalog() { const { data } = await api.get<StaffCatalog>("/staff/catalog"); return data; }
+export async function getStaffById(id: string) { const { data } = await api.get<StaffDetails>(`/staff/${id}`); return data; }
 export async function createStaff(payload: UpsertStaffPayload) { const { data } = await api.post("/staff", payload); return data; }
 export async function updateStaff(id: string, payload: UpsertStaffPayload) { const { data } = await api.put(`/staff/${id}`, payload); return data; }

--- a/novacrm.client/src/pages/Staff.test.tsx
+++ b/novacrm.client/src/pages/Staff.test.tsx
@@ -1,13 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import StaffPage from "./Staff";
+
+const { createStaffMock, updateStaffMock, getStaffByIdMock } = vi.hoisted(() => ({
+  createStaffMock: vi.fn(),
+  updateStaffMock: vi.fn(),
+  getStaffByIdMock: vi.fn(),
+}));
 
 vi.mock("../api/staff", () => ({
   getStaffList: vi.fn(async () => ({ overview: { totalStaff: 1, activeToday: 1, bookedToday: 1, availableToday: 0, avgRating: 4.8, payrollThisMonth: 5000 }, items: [] })),
   getStaffCatalog: vi.fn(async () => ({ roles: [], specializations: [], branches: [], users: [] })),
-  createStaff: vi.fn(),
-  updateStaff: vi.fn(),
+  getStaffById: getStaffByIdMock,
+  createStaff: createStaffMock,
+  updateStaff: updateStaffMock,
 }));
 
 describe("StaffPage", () => {
@@ -16,5 +23,30 @@ describe("StaffPage", () => {
     await waitFor(() => expect(screen.getByRole("heading", { name: "Staff" })).toBeInTheDocument());
     expect(screen.getByText("Total Staff")).toBeInTheDocument();
     expect(screen.getByText("Payroll")).toBeInTheDocument();
+  });
+
+  it("sends deterministic create payload and clears non-selected compensation fields", async () => {
+    createStaffMock.mockResolvedValueOnce({});
+    render(<MemoryRouter><StaffPage /></MemoryRouter>);
+    fireEvent.click((await screen.findAllByRole("button", { name: /Add Staff/i }))[0]);
+    fireEvent.change(screen.getByLabelText("First name"), { target: { value: "Jane" } });
+    fireEvent.change(screen.getByLabelText("Last name"), { target: { value: "Doe" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "Vacation" } });
+    fireEvent.click(screen.getByRole("switch"));
+    fireEvent.change(screen.getByLabelText("Compensation type"), { target: { value: "HourlyRate" } });
+    fireEvent.change(screen.getByLabelText("Hourly rate"), { target: { value: "35" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(createStaffMock).toHaveBeenCalledTimes(1));
+    expect(createStaffMock.mock.calls[0][0]).toMatchObject({
+      firstName: "Jane",
+      lastName: "Doe",
+      employmentStatus: "Vacation",
+      compensationType: "HourlyRate",
+      hourlyRate: 35,
+      fixedSalary: null,
+      commissionPercent: null,
+      hasCrmAccess: true,
+    });
   });
 });

--- a/novacrm.client/src/pages/Staff.tsx
+++ b/novacrm.client/src/pages/Staff.tsx
@@ -3,7 +3,7 @@ import Header from "../layout/Header";
 import ThemeProvider from "../providers/ThemeProvider";
 import { authApi } from "../app/auth";
 import { useNavigate } from "react-router-dom";
-import { createStaff, getStaffCatalog, getStaffList, type StaffCatalog, type StaffItem, updateStaff, type UpsertStaffPayload } from "../api/staff";
+import { createStaff, getStaffById, getStaffCatalog, getStaffList, type StaffCatalog, type StaffItem, updateStaff, type UpsertStaffPayload } from "../api/staff";
 import "../styles/dashboard/index.css";
 import "../styles/clients/index.css";
 import "../styles/staff/index.css";
@@ -11,6 +11,9 @@ import "../styles/staff/index.css";
 const FILTERS = [
   ["all", "All"], ["active", "Active"], ["available", "Available"], ["busy", "Busy"], ["on-leave", "On leave"], ["admin", "Admin"], ["specialist", "Specialist"], ["owner", "Owner"], ["manager", "Manager"], ["top-rated", "Top rated"], ["upcoming", "Has upcoming appointments"]
 ] as const;
+
+type CompensationType = "FixedSalary" | "HourlyRate" | "Commission";
+const STATUS_OPTIONS = ["Active", "Vacation", "Terminated"] as const;
 
 const blankForm = (): UpsertStaffPayload => ({
   branchId: null,
@@ -25,8 +28,53 @@ const blankForm = (): UpsertStaffPayload => ({
   employmentStatus: "Active",
   roleIds: [],
   specializationIds: [],
-  compensation: { compensationType: "Fixed", fixedSalary: 0, hourlyRate: null, commissionPercent: null, perServiceAmount: null, effectiveFrom: new Date().toISOString(), effectiveTo: null, notes: "" }
+  compensationType: "FixedSalary",
+  fixedSalary: null,
+  hourlyRate: null,
+  commissionPercent: null,
 });
+
+const normalizeCompensationType = (type?: string | null): CompensationType => {
+  if (type === "Hourly" || type === "HourlyRate") return "HourlyRate";
+  if (type === "Commission") return "Commission";
+  return "FixedSalary";
+};
+const compensationTypeLabel = (type?: string | null): string => {
+  const normalized = normalizeCompensationType(type);
+  if (normalized === "FixedSalary") return "Fixed salary";
+  if (normalized === "HourlyRate") return "Hourly rate";
+  return "Commission";
+};
+
+const normalizeEmploymentStatus = (status?: string | null): typeof STATUS_OPTIONS[number] => {
+  if (status === "OnLeave") return "Vacation";
+  if (status === "Vacation" || status === "Terminated") return status;
+  return "Active";
+};
+
+const buildPayload = (form: UpsertStaffPayload): UpsertStaffPayload => {
+  const compensationType = normalizeCompensationType(form.compensationType);
+  return {
+    branchId: form.branchId,
+    hasCrmAccess: form.hasCrmAccess,
+    userId: form.hasCrmAccess ? (form.userId?.trim() || null) : null,
+    firstName: form.firstName.trim(),
+    lastName: form.lastName.trim(),
+    phone: form.phone?.trim() || null,
+    email: form.email?.trim() || null,
+    notes: form.notes?.trim() || null,
+    isActive: form.isActive,
+    employmentStatus: normalizeEmploymentStatus(form.employmentStatus),
+    ratingAverage: form.ratingAverage ?? null,
+    ratingCount: form.ratingCount ?? null,
+    roleIds: [...form.roleIds],
+    specializationIds: [...form.specializationIds],
+    compensationType,
+    fixedSalary: compensationType === "FixedSalary" ? form.fixedSalary ?? null : null,
+    hourlyRate: compensationType === "HourlyRate" ? form.hourlyRate ?? null : null,
+    commissionPercent: compensationType === "Commission" ? form.commissionPercent ?? null : null,
+  };
+};
 
 const initials = (firstName: string, lastName: string) => `${firstName[0] ?? ""}${lastName[0] ?? ""}`.toUpperCase();
 
@@ -42,6 +90,8 @@ export default function StaffPage() {
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<StaffItem | null>(null);
   const [form, setForm] = useState<UpsertStaffPayload>(blankForm);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
 
   const load = async () => {
     setIsLoading(true);
@@ -66,50 +116,51 @@ export default function StaffPage() {
 
   const onSave = async () => {
     if (!form.firstName.trim() || !form.lastName.trim()) return;
+    setIsSaving(true);
     try {
-      const nextComp = form.compensation
-        ? {
-          ...form.compensation,
-          fixedSalary: form.compensation.compensationType === "Fixed" ? form.compensation.fixedSalary ?? null : null,
-          hourlyRate: form.compensation.compensationType === "Hourly" ? form.compensation.hourlyRate ?? null : null,
-          commissionPercent: form.compensation.compensationType === "Commission" ? form.compensation.commissionPercent ?? null : null,
-          perServiceAmount: null,
-        }
-        : null;
-      const payload = { ...form, compensation: nextComp };
+      const payload = buildPayload(form);
 
       if (editing) await updateStaff(editing.id, payload); else await createStaff(payload);
+      setSaveMessage("Staff profile saved.");
       setOpen(false); setEditing(null); setForm(blankForm());
       await load();
     } catch {
       setError("Failed to save staff profile. Please try again.");
+    } finally {
+      setIsSaving(false);
     }
   };
 
-  const openCreate = () => { setEditing(null); setForm(blankForm()); setOpen(true); };
-  const openEdit = (item: StaffItem) => {
+  const openCreate = () => { setEditing(null); setForm(blankForm()); setSaveMessage(null); setOpen(true); };
+  const openEdit = async (item: StaffItem) => {
     setEditing(item);
-    setForm({
-      branchId: item.branchId ?? null,
-      hasCrmAccess: item.hasCrmAccess,
-      userId: item.userId,
-      firstName: item.firstName,
-      lastName: item.lastName,
-      phone: item.phone,
-      email: item.email,
-      notes: "",
-      isActive: item.isActive,
-      employmentStatus: item.employmentStatus,
-      roleIds: item.roles.map(r => r.id),
-      specializationIds: item.specializations.map(s => s.id),
-      compensation: item.currentCompensation
-        ? {
-          ...item.currentCompensation,
-          compensationType: ["Fixed", "Hourly", "Commission"].includes(item.currentCompensation.compensationType) ? item.currentCompensation.compensationType : "Fixed"
-        }
-        : { compensationType: "Fixed", fixedSalary: 0, effectiveFrom: new Date().toISOString() }
-    });
-    setOpen(true);
+    try {
+      const details = await getStaffById(item.id);
+      const compensationType = normalizeCompensationType(details.currentCompensation?.compensationType);
+      setForm({
+        branchId: details.branchId ?? null,
+        hasCrmAccess: details.hasCrmAccess,
+        userId: details.userId,
+        firstName: details.firstName,
+        lastName: details.lastName,
+        phone: details.phone,
+        email: details.email,
+        notes: details.notes ?? "",
+        isActive: details.isActive,
+        employmentStatus: normalizeEmploymentStatus(details.employmentStatus),
+        roleIds: details.roles.map(r => r.id),
+        specializationIds: details.specializations.map(s => s.id),
+        compensationType,
+        fixedSalary: compensationType === "FixedSalary" ? details.currentCompensation?.fixedSalary ?? null : null,
+        hourlyRate: compensationType === "HourlyRate" ? details.currentCompensation?.hourlyRate ?? null : null,
+        commissionPercent: compensationType === "Commission" ? details.currentCompensation?.commissionPercent ?? null : null,
+      });
+      setOpen(true);
+      setSaveMessage(null);
+    } catch {
+      setError("Failed to load full staff details.");
+      setEditing(null);
+    }
   };
 
   const staffTitle = useMemo(() => `${overview.totalStaff} team members`, [overview.totalStaff]);
@@ -159,6 +210,7 @@ export default function StaffPage() {
 
         {isLoading ? <div className="staff-state"><div className="clients-skeleton-row" /><p>Loading team data…</p></div> : null}
         {!isLoading && error ? <div className="clients-error"><span>{error}</span><button type="button" className="clients-retry" onClick={() => void load()}>Retry</button></div> : null}
+        {!isLoading && !error && saveMessage ? <div className="clients-empty"><p>{saveMessage}</p></div> : null}
         {!isLoading && !error && data.length === 0 ? <div className="clients-empty staff-state"><div className="clients-empty__icon">✦</div><h3>Your team is empty</h3><p>Add your first staff member to start scheduling, payroll, and CRM access control.</p><button type="button" className="clients-add" onClick={openCreate}><span className="clients-add__text">Add first staff</span></button></div> : null}
 
         {!isLoading && !error && data.length > 0 ? <div className="clients-table-card">
@@ -181,10 +233,10 @@ export default function StaffPage() {
                   <td className="staff-chip-wrap">{item.specializations.slice(0, 3).map(s => <span key={s.id} className="clients-status">{s.name}</span>)}{item.specializations.length > 3 && <span className="clients-status">+{item.specializations.length - 3}</span>}</td>
                   <td>{item.todaySchedule ?? "No schedule"}</td>
                   <td>{item.appointmentsToday} today / {item.appointmentsWeek} week</td>
-                  <td>{item.currentCompensation?.compensationType ?? "—"}</td>
+                  <td>{item.currentCompensation ? compensationTypeLabel(item.currentCompensation.compensationType) : "—"}</td>
                   <td>{item.ratingAverage.toFixed(1)} ({item.ratingCount})</td>
                   <td><span className={`clients-status clients-status--${item.employmentStatus.toLowerCase()}`}>{item.employmentStatus}{item.hasCrmAccess ? " · CRM" : ""}</span></td>
-                  <td><button className="clients-secondary" onClick={() => openEdit(item)}>Edit</button></td>
+                  <td><button className="clients-secondary" onClick={() => void openEdit(item)}>Edit</button></td>
                 </tr>)}
               </tbody>
             </table>
@@ -206,7 +258,7 @@ export default function StaffPage() {
           <label>Last name<input value={form.lastName} onChange={e => setForm(f => ({ ...f, lastName: e.target.value }))} /></label>
           <label>Phone<input value={form.phone ?? ""} onChange={e => setForm(f => ({ ...f, phone: e.target.value }))} /></label>
           <label>Email<input value={form.email ?? ""} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} /></label>
-          <label>Status<select value={form.employmentStatus} onChange={e => setForm(f => ({ ...f, employmentStatus: e.target.value }))}><option value="Active">Active</option><option value="OnLeave">On leave</option><option value="Terminated">Terminated</option></select></label>
+          <label>Status<select value={normalizeEmploymentStatus(form.employmentStatus)} onChange={e => setForm(f => ({ ...f, employmentStatus: e.target.value }))}><option value="Active">Active</option><option value="Vacation">Vacation</option><option value="Terminated">Terminated</option></select></label>
           {shouldShowLocationField ? <label>Location<select value={form.branchId ?? ""} onChange={e => setForm(f => ({ ...f, branchId: e.target.value || null }))}><option value="">Not selected</option>{catalog.branches.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}</select></label> : <label>Location<input value={singleLocation?.name ?? "Main location"} readOnly /></label>}
           <label className="clients-field-wide">Notes<textarea value={form.notes ?? ""} onChange={e => setForm(f => ({ ...f, notes: e.target.value }))} /></label>
         </div>
@@ -217,15 +269,24 @@ export default function StaffPage() {
         <div className="clients-form-grid">
           <label className="clients-field-wide staff-toggle-row"><span>Allow CRM access</span><button type="button" role="switch" aria-checked={form.hasCrmAccess} className={`staff-toggle ${form.hasCrmAccess ? "is-on" : ""}`} onClick={() => setForm(f => ({ ...f, hasCrmAccess: !f.hasCrmAccess, userId: !f.hasCrmAccess ? f.userId : null }))}><span /></button></label>
           {form.hasCrmAccess ? <label className="clients-field-wide">Linked user<select value={form.userId ?? ""} onChange={e => setForm(f => ({ ...f, userId: e.target.value || null }))}><option value="">Link existing user (optional)</option>{catalog.users.map(u => <option key={u.code} value={u.code}>{u.name}</option>)}</select></label> : null}
-          <label>Compensation type<select value={form.compensation?.compensationType ?? "Fixed"} onChange={e => setForm(f => ({ ...f, compensation: { ...f.compensation, compensationType: e.target.value } }))}><option value="Fixed">Fixed salary</option><option value="Hourly">Hourly rate</option><option value="Commission">Commission</option></select></label>
-          {form.compensation?.compensationType === "Hourly" ? <label>Hourly rate<input type="number" value={form.compensation?.hourlyRate ?? ""} onChange={e => setForm(f => ({ ...f, compensation: { ...f.compensation, hourlyRate: Number(e.target.value) } }))} /></label> : null}
-          {form.compensation?.compensationType === "Commission" ? <label>Commission %<input type="number" value={form.compensation?.commissionPercent ?? ""} onChange={e => setForm(f => ({ ...f, compensation: { ...f.compensation, commissionPercent: Number(e.target.value) } }))} /></label> : null}
-          {(!form.compensation?.compensationType || form.compensation.compensationType === "Fixed") ? <label>Monthly salary<input type="number" value={form.compensation?.fixedSalary ?? ""} onChange={e => setForm(f => ({ ...f, compensation: { ...f.compensation, fixedSalary: Number(e.target.value) } }))} /></label> : null}
+          <label>Compensation type<select value={normalizeCompensationType(form.compensationType)} onChange={e => setForm(f => {
+            const compensationType = normalizeCompensationType(e.target.value);
+            return {
+              ...f,
+              compensationType,
+              fixedSalary: compensationType === "FixedSalary" ? f.fixedSalary : null,
+              hourlyRate: compensationType === "HourlyRate" ? f.hourlyRate : null,
+              commissionPercent: compensationType === "Commission" ? f.commissionPercent : null,
+            };
+          })}><option value="FixedSalary">Fixed salary</option><option value="HourlyRate">Hourly rate</option><option value="Commission">Commission</option></select></label>
+          {normalizeCompensationType(form.compensationType) === "HourlyRate" ? <label>Hourly rate<input type="number" value={form.hourlyRate ?? ""} onChange={e => setForm(f => ({ ...f, hourlyRate: e.target.value === "" ? null : Number(e.target.value) }))} /></label> : null}
+          {normalizeCompensationType(form.compensationType) === "Commission" ? <label>Commission %<input type="number" value={form.commissionPercent ?? ""} onChange={e => setForm(f => ({ ...f, commissionPercent: e.target.value === "" ? null : Number(e.target.value) }))} /></label> : null}
+          {normalizeCompensationType(form.compensationType) === "FixedSalary" ? <label>Monthly salary<input type="number" value={form.fixedSalary ?? ""} onChange={e => setForm(f => ({ ...f, fixedSalary: e.target.value === "" ? null : Number(e.target.value) }))} /></label> : null}
         </div>
 
         <footer className="clients-modal__footer">
           <button className="clients-secondary" onClick={() => setOpen(false)}>Cancel</button>
-          <button className="clients-primary" onClick={() => void onSave()}>Save</button>
+          <button className="clients-primary" onClick={() => void onSave()} disabled={isSaving}>{isSaving ? "Saving…" : "Save"}</button>
         </footer>
       </section>
     </div> : null}


### PR DESCRIPTION
### Motivation
- The staff create/edit flow was partially wired: the edit modal was initialized from list-row projections (missing notes/compensation), status and compensation names were inconsistent across UI/backend, and inactive compensation fields could silently survive saves.
- The goal was to make the form save deterministically end-to-end (frontend → API → EF → DB) and to ensure `HasCrmAccess` and `UserId` behave correctly when toggled.

### Description
- Frontend: build a deterministic upsert payload and null inactive compensation fields, load full staff details on edit, enforce exact status options `Active|Vacation|Terminated`, and show only the selected compensation input; key file: `novacrm.client/src/pages/Staff.tsx`.
- API contract: replaced nested `Compensation` DTO on create/update with top-level fields `CompensationType`, `FixedSalary`, `HourlyRate`, `CommissionPercent` so mapping is explicit; key file: `NovaCRM.Server/Contracts/Staff/StaffDtos.cs`.
- Backend: validate/normalize employment status and compensation type, map/normalize compensation values so only the active field is persisted (others are stored as `null`), preserve CRM linkage behavior (`UserId` cleared when `HasCrmAccess` is `false`), and normalize responses for legacy compensation values; key file: `NovaCRM.Server/Controllers/StaffController.cs`.
- EF config: change default `EmploymentStatus` from `"Available"` to `"Active"` to match the UI/backend expectations; key file: `NovaCRM.Data/ApplicationDbContext.cs`.
- Tests and supporting API client: added/updated frontend test and API surface; changed files: `novacrm.client/src/pages/Staff.test.tsx`, `novacrm.client/src/api/staff.ts`, and updated server test `NovaCRM.Server.Tests/Staff/StaffControllerTests.cs`.
- Files changed: `novacrm.client/src/pages/Staff.tsx`, `novacrm.client/src/api/staff.ts`, `novacrm.client/src/pages/Staff.test.tsx`, `NovaCRM.Server/Contracts/Staff/StaffDtos.cs`, `NovaCRM.Server/Controllers/StaffController.cs`, `NovaCRM.Server.Tests/Staff/StaffControllerTests.cs`, `NovaCRM.Data/ApplicationDbContext.cs`.

### Testing
- Frontend unit test run: `npm --prefix novacrm.client run test -- src/pages/Staff.test.tsx --run` executed and the updated tests passed (2 passed).
- Frontend build: `npm --prefix novacrm.client run build` was attempted but failed due to unrelated pre-existing TypeScript issues in other modules (not introduced by these changes).
- Server tests: `dotnet test` could not be executed in this environment because the .NET SDK/runtime is not available, so backend compile/tests were not run here (server unit test updated in repo but not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24379738c832cbb9d68e36865ff06)