### PR TITLE
Refactor Staff: move logic to Domain service and store enums as ints

### DIFF
--- a/NovaCRM.Data/ApplicationDbContext.cs
+++ b/NovaCRM.Data/ApplicationDbContext.cs
@@ -119,7 +119,7 @@ public partial class ApplicationDbContext : DbContext
             entity.HasKey(e => e.Id);
             entity.Property(e => e.FirstName).IsRequired();
             entity.Property(e => e.LastName).IsRequired();
-            entity.Property(e => e.EmploymentStatus).HasDefaultValue("Active");
+            entity.Property(e => e.EmploymentStatus).HasConversion<int>().HasDefaultValue(1);
             entity.Property(e => e.HasCrmAccess).HasDefaultValue(false);
             entity.Property(e => e.RatingAverage).HasPrecision(4, 2).HasDefaultValue(0m);
             entity.Property(e => e.RatingCount).HasDefaultValue(0);
@@ -169,7 +169,7 @@ public partial class ApplicationDbContext : DbContext
         modelBuilder.Entity<StaffCompensation>(entity =>
         {
             entity.HasKey(e => e.Id);
-            entity.Property(e => e.CompensationType).IsRequired();
+            entity.Property(e => e.CompensationType).HasConversion<int>().IsRequired();
             entity.Property(e => e.FixedSalary).HasPrecision(12, 2);
             entity.Property(e => e.HourlyRate).HasPrecision(12, 2);
             entity.Property(e => e.CommissionPercent).HasPrecision(5, 2);

--- a/NovaCRM.Data/Migrations/20260417110000_StoreStaffEnumsAsInts.cs
+++ b/NovaCRM.Data/Migrations/20260417110000_StoreStaffEnumsAsInts.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NovaCRM.Data.Migrations;
+
+public partial class StoreStaffEnumsAsInts : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(@"
+            ALTER TABLE \"Staff\" ADD COLUMN IF NOT EXISTS \"EmploymentStatusInt\" integer NOT NULL DEFAULT 1;
+            UPDATE \"Staff\"
+            SET \"EmploymentStatusInt\" = CASE
+                WHEN \"EmploymentStatus\" ILIKE 'Vacation' OR \"EmploymentStatus\" ILIKE 'OnLeave' THEN 2
+                WHEN \"EmploymentStatus\" ILIKE 'Terminated' THEN 3
+                ELSE 1
+            END;
+            ALTER TABLE \"Staff\" DROP COLUMN \"EmploymentStatus\";
+            ALTER TABLE \"Staff\" RENAME COLUMN \"EmploymentStatusInt\" TO \"EmploymentStatus\";
+
+            ALTER TABLE \"StaffCompensations\" ADD COLUMN IF NOT EXISTS \"CompensationTypeInt\" integer NOT NULL DEFAULT 1;
+            UPDATE \"StaffCompensations\"
+            SET \"CompensationTypeInt\" = CASE
+                WHEN \"CompensationType\" ILIKE 'HourlyRate' OR \"CompensationType\" ILIKE 'Hourly' THEN 2
+                WHEN \"CompensationType\" ILIKE 'Commission' THEN 3
+                ELSE 1
+            END;
+            ALTER TABLE \"StaffCompensations\" DROP COLUMN \"CompensationType\";
+            ALTER TABLE \"StaffCompensations\" RENAME COLUMN \"CompensationTypeInt\" TO \"CompensationType\";
+        ");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(@"
+            ALTER TABLE \"Staff\" ADD COLUMN IF NOT EXISTS \"EmploymentStatusText\" text NOT NULL DEFAULT 'Active';
+            UPDATE \"Staff\"
+            SET \"EmploymentStatusText\" = CASE
+                WHEN \"EmploymentStatus\" = 2 THEN 'Vacation'
+                WHEN \"EmploymentStatus\" = 3 THEN 'Terminated'
+                ELSE 'Active'
+            END;
+            ALTER TABLE \"Staff\" DROP COLUMN \"EmploymentStatus\";
+            ALTER TABLE \"Staff\" RENAME COLUMN \"EmploymentStatusText\" TO \"EmploymentStatus\";
+
+            ALTER TABLE \"StaffCompensations\" ADD COLUMN IF NOT EXISTS \"CompensationTypeText\" text NOT NULL DEFAULT 'FixedSalary';
+            UPDATE \"StaffCompensations\"
+            SET \"CompensationTypeText\" = CASE
+                WHEN \"CompensationType\" = 2 THEN 'HourlyRate'
+                WHEN \"CompensationType\" = 3 THEN 'Commission'
+                ELSE 'FixedSalary'
+            END;
+            ALTER TABLE \"StaffCompensations\" DROP COLUMN \"CompensationType\";
+            ALTER TABLE \"StaffCompensations\" RENAME COLUMN \"CompensationTypeText\" TO \"CompensationType\";
+        ");
+    }
+}

--- a/NovaCRM.Data/Model/Staff.cs
+++ b/NovaCRM.Data/Model/Staff.cs
@@ -1,3 +1,5 @@
+using NovaCRM.Domain.Staff.Model;
+
 namespace NovaCRM.Data.Model;
 
 public partial class Staff
@@ -16,7 +18,7 @@ public partial class Staff
     public string? Address { get; set; }
     public string? Notes { get; set; }
     public DateTime? Birthday { get; set; }
-    public string EmploymentStatus { get; set; } = "Active";
+    public StaffStatusEnum EmploymentStatus { get; set; } = StaffStatusEnum.Active;
     public decimal RatingAverage { get; set; }
     public int RatingCount { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/NovaCRM.Data/Model/StaffCompensation.cs
+++ b/NovaCRM.Data/Model/StaffCompensation.cs
@@ -1,10 +1,12 @@
+using NovaCRM.Domain.Staff.Model;
+
 namespace NovaCRM.Data.Model;
 
 public partial class StaffCompensation
 {
     public Guid Id { get; set; }
     public Guid StaffId { get; set; }
-    public string CompensationType { get; set; } = null!;
+    public CompensationTypeEnum CompensationType { get; set; }
     public decimal? FixedSalary { get; set; }
     public decimal? HourlyRate { get; set; }
     public decimal? CommissionPercent { get; set; }

--- a/NovaCRM.Domain/Staff/Model/CompensationTypeEnum.cs
+++ b/NovaCRM.Domain/Staff/Model/CompensationTypeEnum.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+namespace NovaCRM.Domain.Staff.Model;
 
-namespace NovaCRM.Domain.Staff.Model
+public enum CompensationTypeEnum
 {
-    public enum CompensationTypeEnum
-    {
-        FixiedSalary = 1,
-        HourlyRate = 2,
-        Commission = 3
-    }
+    FixedSalary = 1,
+    HourlyRate = 2,
+    Commission = 3
 }

--- a/NovaCRM.Domain/Staff/Model/EnumOption.cs
+++ b/NovaCRM.Domain/Staff/Model/EnumOption.cs
@@ -1,0 +1,3 @@
+namespace NovaCRM.Domain.Staff.Model;
+
+public sealed record EnumOption(int Id, string Name);

--- a/NovaCRM.Domain/Staff/Model/StaffItem.cs
+++ b/NovaCRM.Domain/Staff/Model/StaffItem.cs
@@ -1,24 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+namespace NovaCRM.Domain.Staff.Model;
 
-namespace NovaCRM.Domain.Staff.Model
+public class StaffItem
 {
-    public class StaffItem
-    {
-        public Guid Id { get; set; }
-        public string FirstName { get; set; } = null!;
-        public string LastName { get; set; } = null!;
-        public string? Phone { get; set; }
-        public string? Email { get; set; }
-        public int Status { get; set; }
-        public Guid LocationId { get; set; }
-        public string? Notes { get; set; }
-        public bool CRMAccess { get; set; }
-        public int CompensationTypeId { get; set; }
-        public int Salary { get; set; }
-        public Guid OrgId { get; set; }
-    }
+    public Guid Id { get; set; }
+    public Guid? BranchId { get; set; }
+    public bool HasCrmAccess { get; set; }
+    public string? UserId { get; set; }
+
+    public string FirstName { get; set; } = null!;
+    public string LastName { get; set; } = null!;
+    public string? Phone { get; set; }
+    public string? Email { get; set; }
+    public string? Notes { get; set; }
+
+    public bool IsActive { get; set; }
+    public StaffStatusEnum Status { get; set; }
+
+    public decimal? FixedSalary { get; set; }
+    public decimal? HourlyRate { get; set; }
+    public decimal? CommissionPercent { get; set; }
+    public CompensationTypeEnum CompensationType { get; set; }
+
+    public decimal? RatingAverage { get; set; }
+    public int? RatingCount { get; set; }
+
+    public IReadOnlyCollection<Guid> RoleIds { get; set; } = Array.Empty<Guid>();
+    public IReadOnlyCollection<Guid> SpecializationIds { get; set; } = Array.Empty<Guid>();
 }

--- a/NovaCRM.Domain/Staff/Model/StaffStatusEnum.cs
+++ b/NovaCRM.Domain/Staff/Model/StaffStatusEnum.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+namespace NovaCRM.Domain.Staff.Model;
 
-namespace NovaCRM.Domain.Staff.Model
+public enum StaffStatusEnum
 {
-    public enum StaffStatusEnum
-    {
-        Active = 1,
-        Vacation = 2,
-        Terminated = 3
-    }
+    Active = 1,
+    Vacation = 2,
+    Terminated = 3
 }

--- a/NovaCRM.Domain/Staff/Model/StaffUpsertInput.cs
+++ b/NovaCRM.Domain/Staff/Model/StaffUpsertInput.cs
@@ -1,0 +1,23 @@
+namespace NovaCRM.Domain.Staff.Model;
+
+public class StaffUpsertInput
+{
+    public Guid? BranchId { get; init; }
+    public bool HasCrmAccess { get; init; }
+    public string? UserId { get; init; }
+    public string FirstName { get; init; } = null!;
+    public string LastName { get; init; } = null!;
+    public string? Phone { get; init; }
+    public string? Email { get; init; }
+    public string? Notes { get; init; }
+    public bool IsActive { get; init; }
+    public int Status { get; init; }
+    public decimal? RatingAverage { get; init; }
+    public int? RatingCount { get; init; }
+    public IReadOnlyCollection<Guid>? RoleIds { get; init; }
+    public IReadOnlyCollection<Guid>? SpecializationIds { get; init; }
+    public int CompensationType { get; init; }
+    public decimal? FixedSalary { get; init; }
+    public decimal? HourlyRate { get; init; }
+    public decimal? CommissionPercent { get; init; }
+}

--- a/NovaCRM.Domain/Staff/Model/StaffValidationException.cs
+++ b/NovaCRM.Domain/Staff/Model/StaffValidationException.cs
@@ -1,0 +1,3 @@
+namespace NovaCRM.Domain.Staff.Model;
+
+public sealed class StaffValidationException(string message) : Exception(message);

--- a/NovaCRM.Domain/Staff/Services/IStaffService.cs
+++ b/NovaCRM.Domain/Staff/Services/IStaffService.cs
@@ -1,14 +1,12 @@
-﻿using NovaCRM.Domain.Staff.Model;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using NovaCRM.Domain.Staff.Model;
 
-namespace NovaCRM.Domain.Staff.Services
+namespace NovaCRM.Domain.Staff.Services;
+
+public interface IStaffService
 {
-    public interface IStaffService
-    {
-        public StaffItem AddStaff(StaffItem staff);
-    }
+    StaffItem BuildForUpsert(StaffUpsertInput input, Guid? existingId = null);
+    IReadOnlyCollection<EnumOption> GetStatusOptions();
+    IReadOnlyCollection<EnumOption> GetCompensationTypeOptions();
+    string GetStatusName(StaffStatusEnum status);
+    string GetCompensationTypeName(CompensationTypeEnum compensationType);
 }

--- a/NovaCRM.Domain/Staff/Services/StaffService.cs
+++ b/NovaCRM.Domain/Staff/Services/StaffService.cs
@@ -1,17 +1,93 @@
-﻿using NovaCRM.Domain.Staff.Model;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using NovaCRM.Domain.Staff.Model;
 
-namespace NovaCRM.Domain.Staff.Services
+namespace NovaCRM.Domain.Staff.Services;
+
+public sealed class StaffService : IStaffService
 {
-    public class StaffService : IStaffService
+    private static readonly Regex EmailRegex = new(@"^[^\s@]+@[^\s@]+\.[^\s@]+$", RegexOptions.Compiled);
+
+    public StaffItem BuildForUpsert(StaffUpsertInput input, Guid? existingId = null)
     {
-        public StaffItem AddStaff(StaffItem staff)
+        if (string.IsNullOrWhiteSpace(input.FirstName)) throw new StaffValidationException("FirstName is required.");
+        if (string.IsNullOrWhiteSpace(input.LastName)) throw new StaffValidationException("LastName is required.");
+        if (!Enum.IsDefined(typeof(StaffStatusEnum), input.Status)) throw new StaffValidationException("Status must be a valid enum value.");
+        if (!Enum.IsDefined(typeof(CompensationTypeEnum), input.CompensationType)) throw new StaffValidationException("CompensationType must be a valid enum value.");
+
+        var email = string.IsNullOrWhiteSpace(input.Email) ? null : input.Email.Trim();
+        if (!string.IsNullOrWhiteSpace(email) && !EmailRegex.IsMatch(email)) throw new StaffValidationException("Email format is invalid.");
+
+        var compensationType = (CompensationTypeEnum)input.CompensationType;
+        var fixedSalary = compensationType == CompensationTypeEnum.FixedSalary ? input.FixedSalary : null;
+        var hourlyRate = compensationType == CompensationTypeEnum.HourlyRate ? input.HourlyRate : null;
+        var commissionPercent = compensationType == CompensationTypeEnum.Commission ? input.CommissionPercent : null;
+
+        ValidateCompensation(compensationType, fixedSalary, hourlyRate, commissionPercent);
+
+        return new StaffItem
         {
-            
+            Id = existingId ?? Guid.NewGuid(),
+            BranchId = input.BranchId,
+            HasCrmAccess = input.HasCrmAccess,
+            UserId = input.HasCrmAccess ? NormalizeNullable(input.UserId) : null,
+            FirstName = input.FirstName.Trim(),
+            LastName = input.LastName.Trim(),
+            Phone = NormalizeNullable(input.Phone),
+            Email = email,
+            Notes = NormalizeNullable(input.Notes),
+            IsActive = input.IsActive,
+            Status = (StaffStatusEnum)input.Status,
+            CompensationType = compensationType,
+            FixedSalary = fixedSalary,
+            HourlyRate = hourlyRate,
+            CommissionPercent = commissionPercent,
+            RatingAverage = input.RatingAverage,
+            RatingCount = input.RatingCount,
+            RoleIds = input.RoleIds?.Distinct().ToArray() ?? Array.Empty<Guid>(),
+            SpecializationIds = input.SpecializationIds?.Distinct().ToArray() ?? Array.Empty<Guid>()
+        };
+    }
+
+    public IReadOnlyCollection<EnumOption> GetStatusOptions() =>
+        Enum.GetValues<StaffStatusEnum>().Select(x => new EnumOption((int)x, GetStatusName(x))).ToArray();
+
+    public IReadOnlyCollection<EnumOption> GetCompensationTypeOptions() =>
+        Enum.GetValues<CompensationTypeEnum>().Select(x => new EnumOption((int)x, GetCompensationTypeName(x))).ToArray();
+
+    public string GetStatusName(StaffStatusEnum status) => status switch
+    {
+        StaffStatusEnum.Active => "Active",
+        StaffStatusEnum.Vacation => "Vacation",
+        StaffStatusEnum.Terminated => "Terminated",
+        _ => status.ToString()
+    };
+
+    public string GetCompensationTypeName(CompensationTypeEnum compensationType) => compensationType switch
+    {
+        CompensationTypeEnum.FixedSalary => "Fixed salary",
+        CompensationTypeEnum.HourlyRate => "Hourly rate",
+        CompensationTypeEnum.Commission => "Commission",
+        _ => compensationType.ToString()
+    };
+
+    private static string? NormalizeNullable(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static void ValidateCompensation(CompensationTypeEnum compensationType, decimal? fixedSalary, decimal? hourlyRate, decimal? commissionPercent)
+    {
+        switch (compensationType)
+        {
+            case CompensationTypeEnum.FixedSalary:
+                if (fixedSalary is null) throw new StaffValidationException("FixedSalary is required for FixedSalary compensation type.");
+                if (fixedSalary < 0) throw new StaffValidationException("FixedSalary cannot be negative.");
+                return;
+            case CompensationTypeEnum.HourlyRate:
+                if (hourlyRate is null) throw new StaffValidationException("HourlyRate is required for HourlyRate compensation type.");
+                if (hourlyRate < 0) throw new StaffValidationException("HourlyRate cannot be negative.");
+                return;
+            case CompensationTypeEnum.Commission:
+                if (commissionPercent is null) throw new StaffValidationException("CommissionPercent is required for Commission compensation type.");
+                if (commissionPercent < 0 || commissionPercent > 100) throw new StaffValidationException("CommissionPercent must be between 0 and 100.");
+                return;
         }
     }
 }

--- a/NovaCRM.Server.Tests/Staff/StaffControllerTests.cs
+++ b/NovaCRM.Server.Tests/Staff/StaffControllerTests.cs
@@ -10,6 +10,7 @@ using NovaCRM.Data;
 using NovaCRM.Data.Model;
 using NovaCRM.Server.Contracts.Staff;
 using NovaCRM.Server.Controllers;
+using NovaCRM.Domain.Staff.Services;
 using NovaCRM.Server.Services;
 using Xunit;
 
@@ -33,15 +34,15 @@ public class StaffControllerTests
             new StaffSpecialization { Id = Guid.NewGuid(), OrganizationId = orgId, Name = "Laser", Code = "laser", IsActive = true });
         await db.SaveChangesAsync();
 
-        var controller = new StaffController(db, new FakeOrgContext(orgId))
+        var controller = new StaffController(db, new FakeOrgContext(orgId), new StaffService())
         {
             ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) } }
         };
 
         var roles = db.StaffRoles.Select(x => x.Id).ToArray();
         var specs = db.StaffSpecializations.Take(2).Select(x => x.Id).ToArray();
-        var create = new UpsertStaffRequest(null, true, "seed-user", "A", "B", "+1", "a@b.com", null, true, "Active", 4.5m, 10, roles, specs,
-            "FixedSalary", 3000, null, null);
+        var create = new UpsertStaffRequest(null, true, "seed-user", "A", "B", "+1", "a@b.com", null, true, 1, 4.5m, 10, roles, specs,
+            1, 3000, null, null);
 
         var createResult = await controller.Create(create, CancellationToken.None);
         var created = Assert.IsType<OkObjectResult>(createResult.Result).Value as StaffDetailsDto;
@@ -52,13 +53,13 @@ public class StaffControllerTests
         Assert.Equal(2, created.Specializations.Count);
 
         var updatedSpecs = db.StaffSpecializations.Skip(1).Select(x => x.Id).ToArray();
-        var updateRequest = create with { SpecializationIds = updatedSpecs, CompensationType = "Commission", FixedSalary = 3200, CommissionPercent = 15 };
+        var updateRequest = create with { SpecializationIds = updatedSpecs, CompensationType = 3, FixedSalary = 3200, CommissionPercent = 15 };
         var updateResult = await controller.Update(created.Id, updateRequest, CancellationToken.None);
         var updated = Assert.IsType<OkObjectResult>(updateResult.Result).Value as StaffDetailsDto;
 
         Assert.NotNull(updated);
         Assert.Equal(2, updated.Specializations.Count);
-        Assert.Equal("Commission", updated.CurrentCompensation?.CompensationType);
+        Assert.Equal(3, updated.CurrentCompensation?.CompensationType);
         Assert.Null(updated.CurrentCompensation?.FixedSalary);
         Assert.True(updated.CompensationHistory.Count >= 2);
     }

--- a/NovaCRM.Server/Contracts/Staff/StaffDtos.cs
+++ b/NovaCRM.Server/Contracts/Staff/StaffDtos.cs
@@ -1,7 +1,8 @@
 namespace NovaCRM.Server.Contracts.Staff;
 
 public record StaffLookupDto(Guid Id, string Name, string Code);
-public record StaffCompensationDto(string CompensationType, decimal? FixedSalary, decimal? HourlyRate, decimal? CommissionPercent, decimal? PerServiceAmount, DateTime EffectiveFrom, DateTime? EffectiveTo, string? Notes);
+public record EnumOptionDto(int Id, string Name);
+public record StaffCompensationDto(int CompensationType, string CompensationTypeName, decimal? FixedSalary, decimal? HourlyRate, decimal? CommissionPercent, decimal? PerServiceAmount, DateTime EffectiveFrom, DateTime? EffectiveTo, string? Notes);
 public record StaffListItemDto(
     Guid Id,
     string FirstName,
@@ -9,7 +10,8 @@ public record StaffListItemDto(
     string? Phone,
     string? Email,
     bool IsActive,
-    string EmploymentStatus,
+    int EmploymentStatus,
+    string EmploymentStatusName,
     decimal RatingAverage,
     int RatingCount,
     Guid? BranchId,
@@ -37,12 +39,12 @@ public record UpsertStaffRequest(
     string? Email,
     string? Notes,
     bool IsActive,
-    string EmploymentStatus,
+    int Status,
     decimal? RatingAverage,
     int? RatingCount,
     IReadOnlyCollection<Guid> RoleIds,
     IReadOnlyCollection<Guid> SpecializationIds,
-    string CompensationType,
+    int CompensationType,
     decimal? FixedSalary,
     decimal? HourlyRate,
     decimal? CommissionPercent);
@@ -58,7 +60,8 @@ public record StaffDetailsDto(
     string? Email,
     string? Notes,
     bool IsActive,
-    string EmploymentStatus,
+    int EmploymentStatus,
+    string EmploymentStatusName,
     decimal RatingAverage,
     int RatingCount,
     IReadOnlyCollection<StaffLookupDto> Roles,
@@ -66,4 +69,10 @@ public record StaffDetailsDto(
     StaffCompensationDto? CurrentCompensation,
     IReadOnlyCollection<StaffCompensationDto> CompensationHistory);
 
-public record StaffCatalogDto(IReadOnlyCollection<StaffLookupDto> Roles, IReadOnlyCollection<StaffLookupDto> Specializations, IReadOnlyCollection<StaffLookupDto> Branches, IReadOnlyCollection<StaffLookupDto> Users);
+public record StaffCatalogDto(
+    IReadOnlyCollection<StaffLookupDto> Roles,
+    IReadOnlyCollection<StaffLookupDto> Specializations,
+    IReadOnlyCollection<StaffLookupDto> Branches,
+    IReadOnlyCollection<StaffLookupDto> Users,
+    IReadOnlyCollection<EnumOptionDto> Statuses,
+    IReadOnlyCollection<EnumOptionDto> CompensationTypes);

--- a/NovaCRM.Server/Controllers/StaffController.cs
+++ b/NovaCRM.Server/Controllers/StaffController.cs
@@ -1,12 +1,13 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using System.Security.Claims;
-using System.Text.RegularExpressions;
 using NovaCRM.Data;
 using NovaCRM.Data.Model;
+using NovaCRM.Domain.Staff.Model;
+using NovaCRM.Domain.Staff.Services;
 using NovaCRM.Server.Contracts.Staff;
 using NovaCRM.Server.Services;
+using System.Security.Claims;
 
 namespace NovaCRM.Server.Controllers;
 
@@ -17,28 +18,14 @@ public class StaffController : ControllerBase
 {
     private readonly ApplicationDbContext _db;
     private readonly IOrganizationContext _organizationContext;
+    private readonly IStaffService _staffService;
 
-    public StaffController(ApplicationDbContext db, IOrganizationContext organizationContext)
+    public StaffController(ApplicationDbContext db, IOrganizationContext organizationContext, IStaffService staffService)
     {
         _db = db;
         _organizationContext = organizationContext;
+        _staffService = staffService;
     }
-
-    private static readonly HashSet<string> AllowedEmploymentStatuses = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "Active",
-        "Vacation",
-        "Terminated"
-    };
-
-    private static readonly HashSet<string> AllowedCompensationTypes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "FixedSalary",
-        "HourlyRate",
-        "Commission"
-    };
-
-    private static readonly Regex EmailRegex = new(@"^[^\s@]+@[^\s@]+\.[^\s@]+$", RegexOptions.Compiled);
 
     [HttpGet("catalog")]
     public async Task<ActionResult<StaffCatalogDto>> GetCatalog(CancellationToken cancellationToken)
@@ -52,11 +39,13 @@ public class StaffController : ControllerBase
             .Select(x => new StaffLookupDto(x.Id, x.Name, x.Code)).ToListAsync(cancellationToken);
         var branches = await _db.Branches.AsNoTracking().Where(x => x.OrganizationId == orgId && x.DeletedAt == null).OrderBy(x => x.Name)
             .Select(x => new StaffLookupDto(x.Id, x.Name, x.Name)).ToListAsync(cancellationToken);
+
         var orgLinkedUserIds = await _db.Staff.AsNoTracking()
             .Where(x => x.OrganizationId == orgId && x.UserId != null && x.DeletedAt == null)
             .Select(x => x.UserId!)
             .Distinct()
             .ToListAsync(cancellationToken);
+
         var currentUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (!string.IsNullOrWhiteSpace(currentUserId) && !orgLinkedUserIds.Contains(currentUserId))
         {
@@ -69,21 +58,22 @@ public class StaffController : ControllerBase
             .Select(x => new StaffLookupDto(Guid.Empty, x.Email ?? x.UserName ?? x.Id, x.Id))
             .ToListAsync(cancellationToken);
 
-        return Ok(new StaffCatalogDto(roles, specializations, branches, users));
+        return Ok(new StaffCatalogDto(
+            roles,
+            specializations,
+            branches,
+            users,
+            _staffService.GetStatusOptions().Select(x => new EnumOptionDto(x.Id, x.Name)).ToArray(),
+            _staffService.GetCompensationTypeOptions().Select(x => new EnumOptionDto(x.Id, x.Name)).ToArray()));
     }
 
     [HttpGet]
-    public async Task<ActionResult<StaffListResponseDto>> Get(
-     [FromQuery] string? search,
-     [FromQuery] string? filter = "all",
-     CancellationToken cancellationToken = default)
+    public async Task<ActionResult<StaffListResponseDto>> Get([FromQuery] string? search, [FromQuery] string? filter = "all", CancellationToken cancellationToken = default)
     {
         var orgId = await _organizationContext.GetOrganizationIdAsync(User, cancellationToken);
         if (orgId is null)
         {
-            return Ok(new StaffListResponseDto(
-                new StaffOverviewDto(0, 0, 0, 0, 0, 0),
-                Array.Empty<StaffListItemDto>()));
+            return Ok(new StaffListResponseDto(new StaffOverviewDto(0, 0, 0, 0, 0, 0), Array.Empty<StaffListItemDto>()));
         }
 
         var now = DateTime.UtcNow;
@@ -95,46 +85,29 @@ public class StaffController : ControllerBase
             .AsNoTracking()
             .Where(s => s.OrganizationId == orgId && s.DeletedAt == null)
             .Include(s => s.Branch)
-            .Include(s => s.StaffRoleLinks)
-                .ThenInclude(x => x.Role)
-            .Include(s => s.StaffSpecializationLinks)
-                .ThenInclude(x => x.Specialization)
+            .Include(s => s.StaffRoleLinks).ThenInclude(x => x.Role)
+            .Include(s => s.StaffSpecializationLinks).ThenInclude(x => x.Specialization)
             .Include(s => s.StaffCompensations)
-            .Include(s => s.Appointments.Where(a =>
-                a.DeletedAt == null &&
-                a.StartAt >= dayStart &&
-                a.StartAt < weekEnd));
+            .Include(s => s.Appointments.Where(a => a.DeletedAt == null && a.StartAt >= dayStart && a.StartAt < weekEnd));
 
         if (!string.IsNullOrWhiteSpace(search))
         {
-            var normalized = search.Trim();
-            var pattern = $"%{normalized}%";
-
+            var pattern = $"%{search.Trim()}%";
             query = query.Where(s =>
                 EF.Functions.ILike(((s.FirstName ?? "") + " " + (s.LastName ?? "")).Trim(), pattern) ||
                 EF.Functions.ILike(s.Phone ?? "", pattern) ||
                 EF.Functions.ILike(s.Email ?? "", pattern) ||
-                s.StaffRoleLinks.Any(r =>
-                    r.Role != null &&
-                    EF.Functions.ILike(r.Role.Name, pattern)) ||
-                s.StaffSpecializationLinks.Any(sp =>
-                    sp.Specialization != null &&
-                    EF.Functions.ILike(sp.Specialization.Name, pattern))
-            );
+                s.StaffRoleLinks.Any(r => r.Role != null && EF.Functions.ILike(r.Role.Name, pattern)) ||
+                s.StaffSpecializationLinks.Any(sp => sp.Specialization != null && EF.Functions.ILike(sp.Specialization.Name, pattern)));
         }
 
         var list = await query.ToListAsync(cancellationToken);
-
         var response = list.Select(s =>
         {
             var apptsToday = s.Appointments.Count(a => a.StartAt >= dayStart && a.StartAt < dayEnd);
             var apptsWeek = s.Appointments.Count;
-
-            var currentComp = s.StaffCompensations
-                .OrderByDescending(x => x.EffectiveFrom)
-                .FirstOrDefault(x =>
-                    x.EffectiveFrom <= now &&
-                    (x.EffectiveTo == null || x.EffectiveTo >= now));
+            var currentComp = s.StaffCompensations.OrderByDescending(x => x.EffectiveFrom).FirstOrDefault(x => x.EffectiveFrom <= now && (x.EffectiveTo == null || x.EffectiveTo >= now));
+            var statusName = _staffService.GetStatusName(s.EmploymentStatus);
 
             return new StaffListItemDto(
                 s.Id,
@@ -143,42 +116,31 @@ public class StaffController : ControllerBase
                 s.Phone,
                 s.Email,
                 s.IsActive,
-                s.EmploymentStatus,
+                (int)s.EmploymentStatus,
+                statusName,
                 s.RatingAverage,
                 s.RatingCount,
                 s.BranchId,
                 s.Branch?.Name,
-                string.Equals(s.EmploymentStatus, "Vacation", StringComparison.OrdinalIgnoreCase)
-                    ? "On vacation"
-                    : (apptsToday > 0 ? $"Busy today ({apptsToday})" : "No appointments today"),
+                s.EmploymentStatus == StaffStatusEnum.Vacation ? "On vacation" : (apptsToday > 0 ? $"Busy today ({apptsToday})" : "No appointments today"),
                 apptsToday,
                 apptsWeek,
                 s.HasCrmAccess,
                 s.UserId,
-                s.StaffRoleLinks
-                    .Where(x => x.Role != null)
-                    .Select(x => new StaffLookupDto(x.RoleId, x.Role.Name, x.Role.Code))
-                    .ToList(),
-                s.StaffSpecializationLinks
-                    .Where(x => x.Specialization != null)
-                    .Select(x => new StaffLookupDto(x.SpecializationId, x.Specialization.Name, x.Specialization.Code))
-                    .ToList(),
-                currentComp == null ? null : ToCompensationDto(currentComp)
-            );
+                s.StaffRoleLinks.Where(x => x.Role != null).Select(x => new StaffLookupDto(x.RoleId, x.Role.Name, x.Role.Code)).ToList(),
+                s.StaffSpecializationLinks.Where(x => x.Specialization != null).Select(x => new StaffLookupDto(x.SpecializationId, x.Specialization.Name, x.Specialization.Code)).ToList(),
+                currentComp == null ? null : ToCompensationDto(currentComp));
         }).ToList();
 
         response = ApplyFilter(response, filter);
 
         var overview = new StaffOverviewDto(
             list.Count,
-            list.Count(s => s.IsActive && s.EmploymentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase)),
+            list.Count(s => s.IsActive && s.EmploymentStatus == StaffStatusEnum.Active),
             list.Count(s => s.Appointments.Any(a => a.StartAt >= dayStart && a.StartAt < dayEnd)),
-            list.Count(s => s.IsActive && s.EmploymentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase) && !s.Appointments.Any(a => a.StartAt >= dayStart && a.StartAt < dayEnd)),
+            list.Count(s => s.IsActive && s.EmploymentStatus == StaffStatusEnum.Active && !s.Appointments.Any(a => a.StartAt >= dayStart && a.StartAt < dayEnd)),
             list.Count > 0 ? Math.Round(list.Average(s => s.RatingAverage), 2) : 0,
-            list.SelectMany(s => s.StaffCompensations)
-                .Where(c => c.FixedSalary.HasValue)
-                .Sum(c => c.FixedSalary ?? 0)
-        );
+            list.SelectMany(s => s.StaffCompensations).Where(c => c.FixedSalary.HasValue).Sum(c => c.FixedSalary ?? 0));
 
         return Ok(new StaffListResponseDto(overview, response));
     }
@@ -194,21 +156,32 @@ public class StaffController : ControllerBase
             .Include(s => s.StaffRoleLinks).ThenInclude(x => x.Role)
             .Include(s => s.StaffSpecializationLinks).ThenInclude(x => x.Specialization)
             .Include(s => s.StaffCompensations)
-            .Include(s => s.StaffCompensationHistories)
             .FirstOrDefaultAsync(cancellationToken);
+
         if (staff is null) return NotFound();
 
         var currentComp = staff.StaffCompensations.OrderByDescending(x => x.EffectiveFrom).FirstOrDefault();
-        var history = staff.StaffCompensations
-            .OrderByDescending(x => x.EffectiveFrom)
-            .Select(ToCompensationDto)
-            .ToList();
+        var history = staff.StaffCompensations.OrderByDescending(x => x.EffectiveFrom).Select(ToCompensationDto).ToList();
 
-        return Ok(new StaffDetailsDto(staff.Id, staff.BranchId, staff.HasCrmAccess, staff.UserId, staff.FirstName, staff.LastName, staff.Phone, staff.Email, staff.Notes,
-            staff.IsActive, staff.EmploymentStatus, staff.RatingAverage, staff.RatingCount,
+        return Ok(new StaffDetailsDto(
+            staff.Id,
+            staff.BranchId,
+            staff.HasCrmAccess,
+            staff.UserId,
+            staff.FirstName,
+            staff.LastName,
+            staff.Phone,
+            staff.Email,
+            staff.Notes,
+            staff.IsActive,
+            (int)staff.EmploymentStatus,
+            _staffService.GetStatusName(staff.EmploymentStatus),
+            staff.RatingAverage,
+            staff.RatingCount,
             staff.StaffRoleLinks.Select(x => new StaffLookupDto(x.RoleId, x.Role.Name, x.Role.Code)).ToList(),
             staff.StaffSpecializationLinks.Select(x => new StaffLookupDto(x.SpecializationId, x.Specialization.Name, x.Specialization.Code)).ToList(),
-            currentComp is null ? null : ToCompensationDto(currentComp), history));
+            currentComp is null ? null : ToCompensationDto(currentComp),
+            history));
     }
 
     [HttpPost]
@@ -217,49 +190,40 @@ public class StaffController : ControllerBase
         var orgId = await _organizationContext.GetOrganizationIdAsync(User, cancellationToken);
         if (orgId is null) return Unauthorized();
 
-        var normalizedStatus = NormalizeEmploymentStatus(request.EmploymentStatus);
-        if (normalizedStatus is null)
+        StaffItem item;
+        try
         {
-            return BadRequest("EmploymentStatus must be one of: Active, Vacation, Terminated.");
+            item = _staffService.BuildForUpsert(ToDomainInput(request));
         }
-
-        var normalizedCompensationType = NormalizeCompensationType(request.CompensationType);
-        if (normalizedCompensationType is null)
+        catch (StaffValidationException ex)
         {
-            return BadRequest("CompensationType must be one of: FixedSalary, HourlyRate, Commission.");
-        }
-
-        var (fixedSalary, hourlyRate, commissionPercent) = NormalizeCompensationValues(normalizedCompensationType, request.FixedSalary, request.HourlyRate, request.CommissionPercent);
-        var validationError = ValidateRequest(request, fixedSalary, hourlyRate, commissionPercent);
-        if (validationError is not null)
-        {
-            return BadRequest(validationError);
+            return BadRequest(ex.Message);
         }
 
         var now = DateTime.UtcNow;
         var staff = new Staff
         {
-            Id = Guid.NewGuid(),
+            Id = item.Id,
             OrganizationId = orgId.Value,
-            BranchId = request.BranchId,
-            HasCrmAccess = request.HasCrmAccess,
-            UserId = request.HasCrmAccess && !string.IsNullOrWhiteSpace(request.UserId) ? request.UserId : null,
-            FirstName = request.FirstName.Trim(),
-            LastName = request.LastName.Trim(),
-            Phone = request.Phone?.Trim(),
-            Email = request.Email?.Trim(),
-            Notes = request.Notes?.Trim(),
-            IsActive = request.IsActive,
-            EmploymentStatus = normalizedStatus,
-            RatingAverage = request.RatingAverage ?? 0,
-            RatingCount = request.RatingCount ?? 0,
+            BranchId = item.BranchId,
+            HasCrmAccess = item.HasCrmAccess,
+            UserId = item.UserId,
+            FirstName = item.FirstName,
+            LastName = item.LastName,
+            Phone = item.Phone,
+            Email = item.Email,
+            Notes = item.Notes,
+            IsActive = item.IsActive,
+            EmploymentStatus = item.Status,
+            RatingAverage = item.RatingAverage ?? 0,
+            RatingCount = item.RatingCount ?? 0,
             CreatedAt = now,
             UpdatedAt = now
         };
 
         _db.Staff.Add(staff);
         await _db.SaveChangesAsync(cancellationToken);
-        await UpsertLinksAndCompensationAsync(staff.Id, orgId.Value, request, normalizedCompensationType, fixedSalary, hourlyRate, commissionPercent, cancellationToken);
+        await UpsertLinksAndCompensationAsync(staff.Id, orgId.Value, item, cancellationToken);
         return await GetById(staff.Id, cancellationToken);
     }
 
@@ -272,41 +236,32 @@ public class StaffController : ControllerBase
         var staff = await _db.Staff.FirstOrDefaultAsync(s => s.OrganizationId == orgId && s.Id == id && s.DeletedAt == null, cancellationToken);
         if (staff is null) return NotFound();
 
-        var normalizedStatus = NormalizeEmploymentStatus(request.EmploymentStatus);
-        if (normalizedStatus is null)
+        StaffItem item;
+        try
         {
-            return BadRequest("EmploymentStatus must be one of: Active, Vacation, Terminated.");
+            item = _staffService.BuildForUpsert(ToDomainInput(request), id);
+        }
+        catch (StaffValidationException ex)
+        {
+            return BadRequest(ex.Message);
         }
 
-        var normalizedCompensationType = NormalizeCompensationType(request.CompensationType);
-        if (normalizedCompensationType is null)
-        {
-            return BadRequest("CompensationType must be one of: FixedSalary, HourlyRate, Commission.");
-        }
-
-        var (fixedSalary, hourlyRate, commissionPercent) = NormalizeCompensationValues(normalizedCompensationType, request.FixedSalary, request.HourlyRate, request.CommissionPercent);
-        var validationError = ValidateRequest(request, fixedSalary, hourlyRate, commissionPercent);
-        if (validationError is not null)
-        {
-            return BadRequest(validationError);
-        }
-
-        staff.BranchId = request.BranchId;
-        staff.HasCrmAccess = request.HasCrmAccess;
-        staff.UserId = request.HasCrmAccess && !string.IsNullOrWhiteSpace(request.UserId) ? request.UserId : null;
-        staff.FirstName = request.FirstName.Trim();
-        staff.LastName = request.LastName.Trim();
-        staff.Phone = request.Phone?.Trim();
-        staff.Email = request.Email?.Trim();
-        staff.Notes = request.Notes?.Trim();
-        staff.IsActive = request.IsActive;
-        staff.EmploymentStatus = normalizedStatus;
-        staff.RatingAverage = request.RatingAverage ?? staff.RatingAverage;
-        staff.RatingCount = request.RatingCount ?? staff.RatingCount;
+        staff.BranchId = item.BranchId;
+        staff.HasCrmAccess = item.HasCrmAccess;
+        staff.UserId = item.UserId;
+        staff.FirstName = item.FirstName;
+        staff.LastName = item.LastName;
+        staff.Phone = item.Phone;
+        staff.Email = item.Email;
+        staff.Notes = item.Notes;
+        staff.IsActive = item.IsActive;
+        staff.EmploymentStatus = item.Status;
+        staff.RatingAverage = item.RatingAverage ?? staff.RatingAverage;
+        staff.RatingCount = item.RatingCount ?? staff.RatingCount;
         staff.UpdatedAt = DateTime.UtcNow;
 
         await _db.SaveChangesAsync(cancellationToken);
-        await UpsertLinksAndCompensationAsync(staff.Id, orgId.Value, request, normalizedCompensationType, fixedSalary, hourlyRate, commissionPercent, cancellationToken);
+        await UpsertLinksAndCompensationAsync(staff.Id, orgId.Value, item, cancellationToken);
         return await GetById(staff.Id, cancellationToken);
     }
 
@@ -314,10 +269,10 @@ public class StaffController : ControllerBase
     {
         return filter?.ToLowerInvariant() switch
         {
-            "active" => source.Where(x => x.IsActive && x.EmploymentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase)).ToList(),
-            "available" => source.Where(x => x.IsActive && x.EmploymentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase) && x.AppointmentsToday == 0).ToList(),
-            "busy" => source.Where(x => x.IsActive && x.EmploymentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase) && x.AppointmentsToday > 0).ToList(),
-            "on-leave" => source.Where(x => x.EmploymentStatus.Equals("Vacation", StringComparison.OrdinalIgnoreCase)).ToList(),
+            "active" => source.Where(x => x.IsActive && x.EmploymentStatus == (int)StaffStatusEnum.Active).ToList(),
+            "available" => source.Where(x => x.IsActive && x.EmploymentStatus == (int)StaffStatusEnum.Active && x.AppointmentsToday == 0).ToList(),
+            "busy" => source.Where(x => x.IsActive && x.EmploymentStatus == (int)StaffStatusEnum.Active && x.AppointmentsToday > 0).ToList(),
+            "on-leave" => source.Where(x => x.EmploymentStatus == (int)StaffStatusEnum.Vacation).ToList(),
             "admin" => source.Where(x => x.Roles.Any(r => r.Code == "admin")).ToList(),
             "specialist" => source.Where(x => x.Roles.Any(r => r.Code == "specialist")).ToList(),
             "owner" => source.Where(x => x.Roles.Any(r => r.Code == "owner")).ToList(),
@@ -328,44 +283,28 @@ public class StaffController : ControllerBase
         };
     }
 
-    private async Task UpsertLinksAndCompensationAsync(
-        Guid staffId,
-        Guid orgId,
-        UpsertStaffRequest request,
-        string compensationType,
-        decimal? fixedSalary,
-        decimal? hourlyRate,
-        decimal? commissionPercent,
-        CancellationToken cancellationToken)
+    private async Task UpsertLinksAndCompensationAsync(Guid staffId, Guid orgId, StaffItem item, CancellationToken cancellationToken)
     {
-        var requestRoleIds = request.RoleIds ?? Array.Empty<Guid>();
-        var requestSpecIds = request.SpecializationIds ?? Array.Empty<Guid>();
-        var roleIds = await _db.StaffRoles.Where(r => r.OrganizationId == orgId && requestRoleIds.Contains(r.Id)).Select(r => r.Id).ToListAsync(cancellationToken);
-        var specIds = await _db.StaffSpecializations.Where(s => s.OrganizationId == orgId && requestSpecIds.Contains(s.Id)).Select(s => s.Id).ToListAsync(cancellationToken);
+        var roleIds = await _db.StaffRoles.Where(r => r.OrganizationId == orgId && item.RoleIds.Contains(r.Id)).Select(r => r.Id).ToListAsync(cancellationToken);
+        var specIds = await _db.StaffSpecializations.Where(s => s.OrganizationId == orgId && item.SpecializationIds.Contains(s.Id)).Select(s => s.Id).ToListAsync(cancellationToken);
 
-        var currentRoles = _db.StaffRoleLinks.Where(x => x.StaffId == staffId);
-        _db.StaffRoleLinks.RemoveRange(currentRoles);
+        _db.StaffRoleLinks.RemoveRange(_db.StaffRoleLinks.Where(x => x.StaffId == staffId));
         _db.StaffRoleLinks.AddRange(roleIds.Select(id => new StaffRoleLink { StaffId = staffId, RoleId = id, CreatedAt = DateTime.UtcNow }));
 
-        var currentSpecs = _db.StaffSpecializationLinks.Where(x => x.StaffId == staffId);
-        _db.StaffSpecializationLinks.RemoveRange(currentSpecs);
+        _db.StaffSpecializationLinks.RemoveRange(_db.StaffSpecializationLinks.Where(x => x.StaffId == staffId));
         _db.StaffSpecializationLinks.AddRange(specIds.Select(id => new StaffSpecializationLink { StaffId = staffId, SpecializationId = id, CreatedAt = DateTime.UtcNow }));
 
         var latest = await _db.StaffCompensations.Where(x => x.StaffId == staffId).OrderByDescending(x => x.EffectiveFrom).FirstOrDefaultAsync(cancellationToken);
-        if (latest is null ||
-            !string.Equals(latest.CompensationType, compensationType, StringComparison.OrdinalIgnoreCase) ||
-            latest.FixedSalary != fixedSalary ||
-            latest.HourlyRate != hourlyRate ||
-            latest.CommissionPercent != commissionPercent)
+        if (latest is null || latest.CompensationType != item.CompensationType || latest.FixedSalary != item.FixedSalary || latest.HourlyRate != item.HourlyRate || latest.CommissionPercent != item.CommissionPercent)
         {
             _db.StaffCompensations.Add(new StaffCompensation
             {
                 Id = Guid.NewGuid(),
                 StaffId = staffId,
-                CompensationType = compensationType,
-                FixedSalary = fixedSalary,
-                HourlyRate = hourlyRate,
-                CommissionPercent = commissionPercent,
+                CompensationType = item.CompensationType,
+                FixedSalary = item.FixedSalary,
+                HourlyRate = item.HourlyRate,
+                CommissionPercent = item.CommissionPercent,
                 PerServiceAmount = null,
                 EffectiveFrom = DateTime.UtcNow,
                 EffectiveTo = null,
@@ -377,8 +316,8 @@ public class StaffController : ControllerBase
             {
                 Id = Guid.NewGuid(),
                 StaffId = staffId,
-                PreviousSnapshot = latest is null ? null : $"{latest.CompensationType}:{latest.FixedSalary}:{latest.HourlyRate}:{latest.CommissionPercent}:{latest.PerServiceAmount}",
-                NewSnapshot = $"{compensationType}:{fixedSalary}:{hourlyRate}:{commissionPercent}:",
+                PreviousSnapshot = latest is null ? null : $"{(int)latest.CompensationType}:{latest.FixedSalary}:{latest.HourlyRate}:{latest.CommissionPercent}:{latest.PerServiceAmount}",
+                NewSnapshot = $"{(int)item.CompensationType}:{item.FixedSalary}:{item.HourlyRate}:{item.CommissionPercent}:",
                 ChangedAt = DateTime.UtcNow,
                 ChangedBy = User.Identity?.Name,
                 Notes = null
@@ -388,95 +327,28 @@ public class StaffController : ControllerBase
         await _db.SaveChangesAsync(cancellationToken);
     }
 
-    private static string? NormalizeEmploymentStatus(string? status)
+    private StaffCompensationDto ToCompensationDto(StaffCompensation compensation)
+        => new((int)compensation.CompensationType, _staffService.GetCompensationTypeName(compensation.CompensationType), compensation.FixedSalary, compensation.HourlyRate, compensation.CommissionPercent, null, compensation.EffectiveFrom, compensation.EffectiveTo, compensation.Notes);
+
+    private static StaffUpsertInput ToDomainInput(UpsertStaffRequest request) => new()
     {
-        if (string.IsNullOrWhiteSpace(status))
-        {
-            return null;
-        }
-
-        var normalized = status.Trim();
-        if (string.Equals(normalized, "OnLeave", StringComparison.OrdinalIgnoreCase))
-        {
-            normalized = "Vacation";
-        }
-
-        return AllowedEmploymentStatuses.Contains(normalized) ? AllowedEmploymentStatuses.Single(x => x.Equals(normalized, StringComparison.OrdinalIgnoreCase)) : null;
-    }
-
-    private static string? NormalizeCompensationType(string? compensationType)
-    {
-        if (string.IsNullOrWhiteSpace(compensationType))
-        {
-            return null;
-        }
-
-        var normalized = compensationType.Trim();
-        normalized = normalized switch
-        {
-            "Fixed" => "FixedSalary",
-            "Hourly" => "HourlyRate",
-            _ => normalized
-        };
-
-        return AllowedCompensationTypes.Contains(normalized)
-            ? AllowedCompensationTypes.Single(x => x.Equals(normalized, StringComparison.OrdinalIgnoreCase))
-            : null;
-    }
-
-    private static (decimal? FixedSalary, decimal? HourlyRate, decimal? CommissionPercent) NormalizeCompensationValues(string compensationType, decimal? fixedSalary, decimal? hourlyRate, decimal? commissionPercent)
-    {
-        return compensationType switch
-        {
-            "FixedSalary" => (fixedSalary, null, null),
-            "HourlyRate" => (null, hourlyRate, null),
-            "Commission" => (null, null, commissionPercent),
-            _ => (null, null, null)
-        };
-    }
-
-    private static StaffCompensationDto ToCompensationDto(StaffCompensation compensation)
-    {
-        var normalizedCompensationType = NormalizeCompensationType(compensation.CompensationType) ?? "FixedSalary";
-        var (fixedSalary, hourlyRate, commissionPercent) = NormalizeCompensationValues(normalizedCompensationType, compensation.FixedSalary, compensation.HourlyRate, compensation.CommissionPercent);
-        return new StaffCompensationDto(
-            normalizedCompensationType,
-            fixedSalary,
-            hourlyRate,
-            commissionPercent,
-            null,
-            compensation.EffectiveFrom,
-            compensation.EffectiveTo,
-            compensation.Notes);
-    }
-
-    private static string? ValidateRequest(UpsertStaffRequest request, decimal? fixedSalary, decimal? hourlyRate, decimal? commissionPercent)
-    {
-        if (string.IsNullOrWhiteSpace(request.FirstName))
-        {
-            return "FirstName is required.";
-        }
-
-        if (string.IsNullOrWhiteSpace(request.LastName))
-        {
-            return "LastName is required.";
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.Email) && !EmailRegex.IsMatch(request.Email.Trim()))
-        {
-            return "Email format is invalid.";
-        }
-
-        var normalizedCompensationType = NormalizeCompensationType(request.CompensationType) ?? "FixedSalary";
-        return normalizedCompensationType switch
-        {
-            "FixedSalary" when fixedSalary is null => "FixedSalary is required for FixedSalary compensation type.",
-            "FixedSalary" when fixedSalary < 0 => "FixedSalary cannot be negative.",
-            "HourlyRate" when hourlyRate is null => "HourlyRate is required for HourlyRate compensation type.",
-            "HourlyRate" when hourlyRate < 0 => "HourlyRate cannot be negative.",
-            "Commission" when commissionPercent is null => "CommissionPercent is required for Commission compensation type.",
-            "Commission" when commissionPercent < 0 || commissionPercent > 100 => "CommissionPercent must be between 0 and 100.",
-            _ => null
-        };
-    }
+        BranchId = request.BranchId,
+        HasCrmAccess = request.HasCrmAccess,
+        UserId = request.UserId,
+        FirstName = request.FirstName,
+        LastName = request.LastName,
+        Phone = request.Phone,
+        Email = request.Email,
+        Notes = request.Notes,
+        IsActive = request.IsActive,
+        Status = request.Status,
+        RatingAverage = request.RatingAverage,
+        RatingCount = request.RatingCount,
+        RoleIds = request.RoleIds,
+        SpecializationIds = request.SpecializationIds,
+        CompensationType = request.CompensationType,
+        FixedSalary = request.FixedSalary,
+        HourlyRate = request.HourlyRate,
+        CommissionPercent = request.CommissionPercent
+    };
 }

--- a/NovaCRM.Server/Program.cs
+++ b/NovaCRM.Server/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
+using NovaCRM.Domain.Staff.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -61,6 +62,7 @@ builder.Services.AddScoped<IOrganizationContext, OrganizationContext>();
 builder.Services.AddScoped<IClientRepository, ClientRepository>();
 builder.Services.AddScoped<IClientService, ClientService>();
 builder.Services.AddScoped<IDashboardService, DashboardService>();
+builder.Services.AddScoped<IStaffService, StaffService>();
 
 var frontendOrigin = builder.Configuration["FrontendOrigin"] ?? "https://localhost:58876";
 

--- a/NovaCRM.Server/Services/DataSeeder.cs
+++ b/NovaCRM.Server/Services/DataSeeder.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using NovaCRM.Data;
 using NovaCRM.Data.Model;
+using NovaCRM.Domain.Staff.Model;
 
 namespace NovaCRM.Server.Services;
 
@@ -48,20 +49,20 @@ public static class DataSeeder
         };
         var specializations = specializationsData.Select((x, i) => new StaffSpecialization { Id = Guid.NewGuid(), OrganizationId = organization.Id, Name = x.Name, Code = x.Code, Category = x.Category, SortOrder = i + 1, IsActive = true }).ToArray();
 
-        Staff staff(string first, string last, Branch branch, string status, decimal rating, int count, bool hasCrmAccess, string? userId = null) => new()
+        Staff staff(string first, string last, Branch branch, StaffStatusEnum status, decimal rating, int count, bool hasCrmAccess, string? userId = null) => new()
         {
             Id = Guid.NewGuid(), OrganizationId = organization.Id, BranchId = branch.Id, HasCrmAccess = hasCrmAccess, UserId = hasCrmAccess ? userId : null, FirstName = first, LastName = last, RoleTitle = "Team", Phone = $"+1 555 01{Random.Shared.Next(10,99)}", Email = $"{first.ToLower()}.{last.ToLower()}@novacrm.demo", IsActive = true, EmploymentStatus = status, RatingAverage = rating, RatingCount = count, CreatedAt = now, UpdatedAt = now
         };
 
         var staffMembers = new[]
         {
-            staff("Demo", "Owner", downtown, "Active", 4.9m, 55, true, user.Id),
-            staff("Maya", "Lash", downtown, "Active", 4.8m, 31, false),
-            staff("Olga", "Admin", downtown, "Active", 4.7m, 24, true),
-            staff("Iris", "Inject", uptown, "Active", 4.95m, 40, true),
-            staff("Nora", "Nails", uptown, "Active", 4.6m, 22, false),
-            staff("Helen", "Hair", downtown, "OnLeave", 4.5m, 18, false),
-            staff("Sam", "Manager", downtown, "Terminated", 4.4m, 11, true)
+            staff("Demo", "Owner", downtown, StaffStatusEnum.Active, 4.9m, 55, true, user.Id),
+            staff("Maya", "Lash", downtown, StaffStatusEnum.Active, 4.8m, 31, false),
+            staff("Olga", "Admin", downtown, StaffStatusEnum.Active, 4.7m, 24, true),
+            staff("Iris", "Inject", uptown, StaffStatusEnum.Active, 4.95m, 40, true),
+            staff("Nora", "Nails", uptown, StaffStatusEnum.Active, 4.6m, 22, false),
+            staff("Helen", "Hair", downtown, StaffStatusEnum.Vacation, 4.5m, 18, false),
+            staff("Sam", "Manager", downtown, StaffStatusEnum.Terminated, 4.4m, 11, true)
         };
 
         var roleMap = roles.ToDictionary(x => x.Code);
@@ -91,13 +92,13 @@ public static class DataSeeder
 
         var compensations = new[]
         {
-            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[0].Id,CompensationType="Hybrid",FixedSalary=6000,CommissionPercent=12,EffectiveFrom=now.AddMonths(-2),Notes="Owner compensation",CreatedAt=now},
-            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[1].Id,CompensationType="Commission",CommissionPercent=35,PerServiceAmount=15,EffectiveFrom=now.AddMonths(-1),CreatedAt=now},
-            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[2].Id,CompensationType="Hourly",HourlyRate=35,EffectiveFrom=now.AddMonths(-3),CreatedAt=now},
-            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[3].Id,CompensationType="Hybrid",FixedSalary=4500,CommissionPercent=20,EffectiveFrom=now.AddMonths(-1),CreatedAt=now},
-            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[4].Id,CompensationType="Fixed",FixedSalary=3800,EffectiveFrom=now.AddMonths(-1),CreatedAt=now},
-            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[5].Id,CompensationType="Fixed",FixedSalary=4200,EffectiveFrom=now.AddMonths(-1),CreatedAt=now},
-            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[6].Id,CompensationType="Fixed",FixedSalary=5000,EffectiveFrom=now.AddMonths(-1),CreatedAt=now}
+            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[0].Id,CompensationType=CompensationTypeEnum.FixedSalary,FixedSalary=6000,EffectiveFrom=now.AddMonths(-2),Notes="Owner compensation",CreatedAt=now},
+            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[1].Id,CompensationType=CompensationTypeEnum.Commission,CommissionPercent=35,PerServiceAmount=15,EffectiveFrom=now.AddMonths(-1),CreatedAt=now},
+            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[2].Id,CompensationType=CompensationTypeEnum.HourlyRate,HourlyRate=35,EffectiveFrom=now.AddMonths(-3),CreatedAt=now},
+            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[3].Id,CompensationType=CompensationTypeEnum.FixedSalary,FixedSalary=4500,EffectiveFrom=now.AddMonths(-1),CreatedAt=now},
+            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[4].Id,CompensationType=CompensationTypeEnum.FixedSalary,FixedSalary=3800,EffectiveFrom=now.AddMonths(-1),CreatedAt=now},
+            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[5].Id,CompensationType=CompensationTypeEnum.FixedSalary,FixedSalary=4200,EffectiveFrom=now.AddMonths(-1),CreatedAt=now},
+            new StaffCompensation{Id=Guid.NewGuid(),StaffId=staffMembers[6].Id,CompensationType=CompensationTypeEnum.FixedSalary,FixedSalary=5000,EffectiveFrom=now.AddMonths(-1),CreatedAt=now}
         };
 
         var services = new[]
@@ -138,7 +139,7 @@ public static class DataSeeder
         db.StaffRoleLinks.AddRange(roleLinks);
         db.StaffSpecializationLinks.AddRange(specLinks);
         db.StaffCompensations.AddRange(compensations);
-        db.StaffCompensationHistories.AddRange(compensations.Select(c => new StaffCompensationHistory{Id=Guid.NewGuid(),StaffId=c.StaffId,NewSnapshot=$"{c.CompensationType}:{c.FixedSalary}:{c.HourlyRate}:{c.CommissionPercent}:{c.PerServiceAmount}",ChangedAt=now,Notes="Initial seed compensation"}));
+        db.StaffCompensationHistories.AddRange(compensations.Select(c => new StaffCompensationHistory{Id=Guid.NewGuid(),StaffId=c.StaffId,NewSnapshot=$"{(int)c.CompensationType}:{c.FixedSalary}:{c.HourlyRate}:{c.CommissionPercent}:{c.PerServiceAmount}",ChangedAt=now,Notes="Initial seed compensation"}));
         db.Clients.AddRange(clients);
         db.Services.AddRange(services);
         db.Appointments.AddRange(appointments);

--- a/novacrm.client/src/api/staff.ts
+++ b/novacrm.client/src/api/staff.ts
@@ -1,23 +1,24 @@
 import { api } from "../app/auth";
 
 export interface StaffLookup { id: string; name: string; code: string; }
-export interface StaffCompensation { compensationType: string; fixedSalary?: number | null; hourlyRate?: number | null; commissionPercent?: number | null; perServiceAmount?: number | null; effectiveFrom: string; effectiveTo?: string | null; notes?: string | null; }
+export interface EnumOption { id: number; name: string; }
+export interface StaffCompensation { compensationType: number; compensationTypeName: string; fixedSalary?: number | null; hourlyRate?: number | null; commissionPercent?: number | null; perServiceAmount?: number | null; effectiveFrom: string; effectiveTo?: string | null; notes?: string | null; }
 export interface StaffDetails extends StaffItem {
   notes?: string | null;
 }
 export interface StaffItem {
-  id: string; firstName: string; lastName: string; phone?: string | null; email?: string | null; isActive: boolean; employmentStatus: string;
+  id: string; firstName: string; lastName: string; phone?: string | null; email?: string | null; isActive: boolean; employmentStatus: number; employmentStatusName: string;
   ratingAverage: number; ratingCount: number; branchId?: string | null; branchName?: string | null; todaySchedule?: string | null; appointmentsToday: number; appointmentsWeek: number;
   hasCrmAccess: boolean; userId?: string | null;
   roles: StaffLookup[]; specializations: StaffLookup[]; currentCompensation?: StaffCompensation | null;
 }
 export interface StaffOverview { totalStaff: number; activeToday: number; bookedToday: number; availableToday: number; avgRating: number; payrollThisMonth: number; }
 export interface StaffListResponse { overview: StaffOverview; items: StaffItem[]; }
-export interface StaffCatalog { roles: StaffLookup[]; specializations: StaffLookup[]; branches: StaffLookup[]; users: StaffLookup[]; }
+export interface StaffCatalog { roles: StaffLookup[]; specializations: StaffLookup[]; branches: StaffLookup[]; users: StaffLookup[]; statuses: EnumOption[]; compensationTypes: EnumOption[]; }
 export interface UpsertStaffPayload {
   branchId?: string | null; hasCrmAccess: boolean; userId?: string | null; firstName: string; lastName: string; phone?: string | null; email?: string | null; notes?: string | null;
-  isActive: boolean; employmentStatus: string; ratingAverage?: number | null; ratingCount?: number | null; roleIds: string[]; specializationIds: string[];
-  compensationType: string; fixedSalary?: number | null; hourlyRate?: number | null; commissionPercent?: number | null;
+  isActive: boolean; status: number; ratingAverage?: number | null; ratingCount?: number | null; roleIds: string[]; specializationIds: string[];
+  compensationType: number; fixedSalary?: number | null; hourlyRate?: number | null; commissionPercent?: number | null;
 }
 export async function getStaffList(search?: string, filter?: string) { const { data } = await api.get<StaffListResponse>("/staff", { params: { search, filter } }); return data; }
 export async function getStaffCatalog() { const { data } = await api.get<StaffCatalog>("/staff/catalog"); return data; }

--- a/novacrm.client/src/pages/Staff.tsx
+++ b/novacrm.client/src/pages/Staff.tsx
@@ -12,8 +12,7 @@ const FILTERS = [
   ["all", "All"], ["active", "Active"], ["available", "Available"], ["busy", "Busy"], ["on-leave", "On leave"], ["admin", "Admin"], ["specialist", "Specialist"], ["owner", "Owner"], ["manager", "Manager"], ["top-rated", "Top rated"], ["upcoming", "Has upcoming appointments"]
 ] as const;
 
-type CompensationType = "FixedSalary" | "HourlyRate" | "Commission";
-const STATUS_OPTIONS = ["Active", "Vacation", "Terminated"] as const;
+type CompensationType = 1 | 2 | 3;
 
 const blankForm = (): UpsertStaffPayload => ({
   branchId: null,
@@ -25,32 +24,17 @@ const blankForm = (): UpsertStaffPayload => ({
   email: "",
   notes: "",
   isActive: true,
-  employmentStatus: "Active",
+  status: 1,
   roleIds: [],
   specializationIds: [],
-  compensationType: "FixedSalary",
+  compensationType: 1,
   fixedSalary: null,
   hourlyRate: null,
   commissionPercent: null,
 });
 
-const normalizeCompensationType = (type?: string | null): CompensationType => {
-  if (type === "Hourly" || type === "HourlyRate") return "HourlyRate";
-  if (type === "Commission") return "Commission";
-  return "FixedSalary";
-};
-const compensationTypeLabel = (type?: string | null): string => {
-  const normalized = normalizeCompensationType(type);
-  if (normalized === "FixedSalary") return "Fixed salary";
-  if (normalized === "HourlyRate") return "Hourly rate";
-  return "Commission";
-};
-
-const normalizeEmploymentStatus = (status?: string | null): typeof STATUS_OPTIONS[number] => {
-  if (status === "OnLeave") return "Vacation";
-  if (status === "Vacation" || status === "Terminated") return status;
-  return "Active";
-};
+const normalizeCompensationType = (type?: number | null): CompensationType => (type === 2 || type === 3 ? type : 1);
+const normalizeStatus = (status?: number | null): number => (status === 2 || status === 3 ? status : 1);
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -63,17 +47,17 @@ const validateForm = (form: UpsertStaffPayload): string | null => {
   }
 
   const compensationType = normalizeCompensationType(form.compensationType);
-  if (compensationType === "FixedSalary") {
+  if (compensationType === 1) {
     if (form.fixedSalary === null || form.fixedSalary === undefined || Number.isNaN(form.fixedSalary)) return "Monthly salary is required.";
     if (form.fixedSalary < 0) return "Monthly salary cannot be negative.";
   }
 
-  if (compensationType === "HourlyRate") {
+  if (compensationType === 2) {
     if (form.hourlyRate === null || form.hourlyRate === undefined || Number.isNaN(form.hourlyRate)) return "Hourly rate is required.";
     if (form.hourlyRate < 0) return "Hourly rate cannot be negative.";
   }
 
-  if (compensationType === "Commission") {
+  if (compensationType === 3) {
     if (form.commissionPercent === null || form.commissionPercent === undefined || Number.isNaN(form.commissionPercent)) return "Commission percent is required.";
     if (form.commissionPercent < 0 || form.commissionPercent > 100) return "Commission percent must be between 0 and 100.";
   }
@@ -93,15 +77,15 @@ const buildPayload = (form: UpsertStaffPayload): UpsertStaffPayload => {
     email: form.email?.trim() || null,
     notes: form.notes?.trim() || null,
     isActive: form.isActive,
-    employmentStatus: normalizeEmploymentStatus(form.employmentStatus),
+    status: normalizeStatus(form.status),
     ratingAverage: form.ratingAverage ?? null,
     ratingCount: form.ratingCount ?? null,
     roleIds: [...form.roleIds],
     specializationIds: [...form.specializationIds],
     compensationType,
-    fixedSalary: compensationType === "FixedSalary" ? form.fixedSalary ?? null : null,
-    hourlyRate: compensationType === "HourlyRate" ? form.hourlyRate ?? null : null,
-    commissionPercent: compensationType === "Commission" ? form.commissionPercent ?? null : null,
+    fixedSalary: compensationType === 1 ? form.fixedSalary ?? null : null,
+    hourlyRate: compensationType === 2 ? form.hourlyRate ?? null : null,
+    commissionPercent: compensationType === 3 ? form.commissionPercent ?? null : null,
   };
 };
 
@@ -115,7 +99,7 @@ export default function StaffPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [overview, setOverview] = useState({ totalStaff: 0, activeToday: 0, bookedToday: 0, availableToday: 0, avgRating: 0, payrollThisMonth: 0 });
-  const [catalog, setCatalog] = useState<StaffCatalog>({ roles: [], specializations: [], branches: [], users: [] });
+  const [catalog, setCatalog] = useState<StaffCatalog>({ roles: [], specializations: [], branches: [], users: [], statuses: [], compensationTypes: [] });
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<StaffItem | null>(null);
   const [form, setForm] = useState<UpsertStaffPayload>(blankForm);
@@ -181,13 +165,13 @@ export default function StaffPage() {
         email: details.email,
         notes: details.notes ?? "",
         isActive: details.isActive,
-        employmentStatus: normalizeEmploymentStatus(details.employmentStatus),
+        status: normalizeStatus(details.employmentStatus),
         roleIds: details.roles.map(r => r.id),
         specializationIds: details.specializations.map(s => s.id),
         compensationType,
-        fixedSalary: compensationType === "FixedSalary" ? details.currentCompensation?.fixedSalary ?? null : null,
-        hourlyRate: compensationType === "HourlyRate" ? details.currentCompensation?.hourlyRate ?? null : null,
-        commissionPercent: compensationType === "Commission" ? details.currentCompensation?.commissionPercent ?? null : null,
+        fixedSalary: compensationType === 1 ? details.currentCompensation?.fixedSalary ?? null : null,
+        hourlyRate: compensationType === 2 ? details.currentCompensation?.hourlyRate ?? null : null,
+        commissionPercent: compensationType === 3 ? details.currentCompensation?.commissionPercent ?? null : null,
       });
       setOpen(true);
       setSaveMessage(null);
@@ -267,9 +251,9 @@ export default function StaffPage() {
                   <td className="staff-chip-wrap">{item.specializations.slice(0, 3).map(s => <span key={s.id} className="clients-status">{s.name}</span>)}{item.specializations.length > 3 && <span className="clients-status">+{item.specializations.length - 3}</span>}</td>
                   <td>{item.todaySchedule ?? "No schedule"}</td>
                   <td>{item.appointmentsToday} today / {item.appointmentsWeek} week</td>
-                  <td>{item.currentCompensation ? compensationTypeLabel(item.currentCompensation.compensationType) : "—"}</td>
+                  <td>{item.currentCompensation?.compensationTypeName ?? "—"}</td>
                   <td>{item.ratingAverage.toFixed(1)} ({item.ratingCount})</td>
-                  <td><span className={`clients-status clients-status--${item.employmentStatus.toLowerCase()}`}>{item.employmentStatus}{item.hasCrmAccess ? " · CRM" : ""}</span></td>
+                  <td><span className={`clients-status clients-status--${item.employmentStatusName.toLowerCase()}`}>{item.employmentStatusName}{item.hasCrmAccess ? " · CRM" : ""}</span></td>
                   <td><button className="clients-secondary" onClick={() => void openEdit(item)}>Edit</button></td>
                 </tr>)}
               </tbody>
@@ -292,7 +276,7 @@ export default function StaffPage() {
           <label>Last name<input value={form.lastName} onChange={e => setForm(f => ({ ...f, lastName: e.target.value }))} /></label>
           <label>Phone<input value={form.phone ?? ""} onChange={e => setForm(f => ({ ...f, phone: e.target.value }))} /></label>
           <label>Email<input value={form.email ?? ""} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} /></label>
-          <label>Status<select value={normalizeEmploymentStatus(form.employmentStatus)} onChange={e => setForm(f => ({ ...f, employmentStatus: e.target.value }))}><option value="Active">Active</option><option value="Vacation">Vacation</option><option value="Terminated">Terminated</option></select></label>
+          <label>Status<select value={normalizeStatus(form.status)} onChange={e => setForm(f => ({ ...f, status: Number(e.target.value) }))}>{catalog.statuses.map(o => <option key={o.id} value={o.id}>{o.name}</option>)}</select></label>
           {shouldShowLocationField ? <label>Location<select value={form.branchId ?? ""} onChange={e => setForm(f => ({ ...f, branchId: e.target.value || null }))}><option value="">Not selected</option>{catalog.branches.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}</select></label> : <label>Location<input value={singleLocation?.name ?? "Main location"} readOnly /></label>}
           <label className="clients-field-wide">Notes<textarea value={form.notes ?? ""} onChange={e => setForm(f => ({ ...f, notes: e.target.value }))} /></label>
         </div>
@@ -304,18 +288,18 @@ export default function StaffPage() {
           <label className="clients-field-wide staff-toggle-row"><span>Allow CRM access</span><button type="button" role="switch" aria-checked={form.hasCrmAccess} className={`staff-toggle ${form.hasCrmAccess ? "is-on" : ""}`} onClick={() => setForm(f => ({ ...f, hasCrmAccess: !f.hasCrmAccess, userId: !f.hasCrmAccess ? f.userId : null }))}><span /></button></label>
           {form.hasCrmAccess ? <label className="clients-field-wide">Linked user<select value={form.userId ?? ""} onChange={e => setForm(f => ({ ...f, userId: e.target.value || null }))}><option value="">Link existing user (optional)</option>{catalog.users.map(u => <option key={u.code} value={u.code}>{u.name}</option>)}</select></label> : null}
           <label>Compensation type<select value={normalizeCompensationType(form.compensationType)} onChange={e => setForm(f => {
-            const compensationType = normalizeCompensationType(e.target.value);
+            const compensationType = normalizeCompensationType(Number(e.target.value));
             return {
               ...f,
               compensationType,
-              fixedSalary: compensationType === "FixedSalary" ? f.fixedSalary : null,
-              hourlyRate: compensationType === "HourlyRate" ? f.hourlyRate : null,
-              commissionPercent: compensationType === "Commission" ? f.commissionPercent : null,
+              fixedSalary: compensationType === 1 ? f.fixedSalary : null,
+              hourlyRate: compensationType === 2 ? f.hourlyRate : null,
+              commissionPercent: compensationType === 3 ? f.commissionPercent : null,
             };
-          })}><option value="FixedSalary">Fixed salary</option><option value="HourlyRate">Hourly rate</option><option value="Commission">Commission</option></select></label>
-          {normalizeCompensationType(form.compensationType) === "HourlyRate" ? <label>Hourly rate<input type="number" value={form.hourlyRate ?? ""} onChange={e => setForm(f => ({ ...f, hourlyRate: e.target.value === "" ? null : Number(e.target.value) }))} /></label> : null}
-          {normalizeCompensationType(form.compensationType) === "Commission" ? <label>Commission %<input type="number" value={form.commissionPercent ?? ""} onChange={e => setForm(f => ({ ...f, commissionPercent: e.target.value === "" ? null : Number(e.target.value) }))} /></label> : null}
-          {normalizeCompensationType(form.compensationType) === "FixedSalary" ? <label>Monthly salary<input type="number" value={form.fixedSalary ?? ""} onChange={e => setForm(f => ({ ...f, fixedSalary: e.target.value === "" ? null : Number(e.target.value) }))} /></label> : null}
+          })}>{catalog.compensationTypes.map(o => <option key={o.id} value={o.id}>{o.name}</option>)}</select></label>
+          {normalizeCompensationType(form.compensationType) === 2 ? <label>Hourly rate<input type="number" value={form.hourlyRate ?? ""} onChange={e => setForm(f => ({ ...f, hourlyRate: e.target.value === "" ? null : Number(e.target.value) }))} /></label> : null}
+          {normalizeCompensationType(form.compensationType) === 3 ? <label>Commission %<input type="number" value={form.commissionPercent ?? ""} onChange={e => setForm(f => ({ ...f, commissionPercent: e.target.value === "" ? null : Number(e.target.value) }))} /></label> : null}
+          {normalizeCompensationType(form.compensationType) === 1 ? <label>Monthly salary<input type="number" value={form.fixedSalary ?? ""} onChange={e => setForm(f => ({ ...f, fixedSalary: e.target.value === "" ? null : Number(e.target.value) }))} /></label> : null}
         </div>
 
         <footer className="clients-modal__footer">


### PR DESCRIPTION
### Motivation
- Remove business logic from the controller and centralize Staff rules in the Domain layer to make Controller a thin orchestration layer and avoid inconsistencies between UI / API / DB. 
- Replace ad-hoc string-based status/compensation handling with typed enums and store them as integers in the database to provide a single source of truth for frontend dropdowns. 

### Description
- Implemented domain model and service: added `StaffStatusEnum`, `CompensationTypeEnum`, `StaffItem`, `StaffUpsertInput`, `EnumOption`, `StaffValidationException`, `IStaffService` and `StaffService` with all upsert validation/normalization and compensation rules moved into `NovaCRM.Domain/Staff/Services/StaffService` and exposed lookups via `GetStatusOptions()` / `GetCompensationTypeOptions()`. 
- Refactored `StaffController` to be thin: it now maps request DTOs to `StaffUpsertInput`, calls `_staffService.BuildForUpsert(...)`, persists the `Staff` entity and calls `UpsertLinksAndCompensationAsync` with domain-normalized `StaffItem`. 
- Switched DTOs and frontend contracts to numeric enums: updated `UpsertStaffRequest`, `StaffDetailsDto`, `StaffListItemDto`, `StaffCompensationDto`, `StaffCatalogDto`, `novacrm.client/src/api/staff.ts` and `novacrm.client/src/pages/Staff.tsx` to use integer `status`/`compensationType` and to consume backend enum-backed lookups for dropdowns. 
- Updated EF and data models to persist enums as ints: `Staff.EmploymentStatus` and `StaffCompensation.CompensationType` are now enum properties and `ApplicationDbContext` uses `.HasConversion<int>()`. 
- Added DB migration `20260417110000_StoreStaffEnumsAsInts` that converts legacy text values in `Staff` and `StaffCompensations` into integer enum columns and provides a `Down` script to roll back to text. 
- Updated DI registration (`IStaffService`), seed data (`DataSeeder`) and adjusted server tests to use the new service and numeric enum payloads. 

### Testing
- Attempted `dotnet test NovaCRM.sln`, but it failed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- Attempted frontend build with `npm run build --prefix novacrm.client`, which failed due to existing TypeScript test/helper issues unrelated to Staff changes (matcher typings / vite config), so no successful client build verification was performed. 
- Unit tests in `NovaCRM.Server.Tests/Staff/StaffControllerTests.cs` were updated to use the new service/enum-int payloads, but could not be executed in CI here due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2b0e5d2ec832c93a31dd0f077e454)